### PR TITLE
Update grouping logic per instructions

### DIFF
--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -20,7 +20,7 @@ def test_columns():
 def test_n_row():
     n_row = out.loc["N="]
     assert n_row["Total"] == len(tbl.df)
-    assert n_row["Combination"] + n_row["Monotherapy"] == len(tbl.df)
+    assert n_row["Combination"] + n_row["Monotherapy"] <= len(tbl.df)
 
 
 def test_rows():


### PR DESCRIPTION
## Summary
- include `Total,n=104` sheet in table generation
- handle therapy label more carefully and add 'Unknown'
- refine grouping rules for disease, immune therapy, steroids, vaccination, CT changes, variant and adverse events
- compute percentages using column-specific denominators
- adjust tests for new logic

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687eb3cf44448333939f7abfd2352371