### PR TITLE
Move flag logic to preprocessing

### DIFF
--- a/data_preprocessing.py
+++ b/data_preprocessing.py
@@ -238,11 +238,23 @@ def add_flags_extended(df: pd.DataFrame) -> pd.DataFrame:
     df['trans'] = dis.map(transp_subtype)
     df['group'] = df[COL_DIS].map(disease_group)
     df['immu'] = df[COL_BASE].map(immuno_cat)
+    s = df[COL_DIS].astype(str).str.lower()
+    df['flag_malign'] = s.str.contains('m')
+    df['flag_autoimm'] = s.str.contains('a')
+    df['flag_transpl'] = s.str.contains('t')
+    base = df[COL_BASE].map(group_immuno)
+    df['flag_cd20'] = base == 'CD20'
+    df['flag_cart'] = base == 'CAR-T'
+    df['flag_hsct'] = base == 'HSCT'
+    df['flag_immuno_none'] = ~(
+        df[['flag_cd20', 'flag_cart', 'flag_hsct']].any(axis=1)
+    ) | (base == 'none')
     df['flag_gc'] = df[COL_GC].astype(str).str.lower().str.startswith('y')
     vacc = df[COL_VACC].map(parse_vacc)
     df['vacc_yes'] = vacc.map(lambda x: x[0] == 'Yes')
     df['dose_vec'] = vacc.map(lambda x: x[1])
     df['flag_ct'] = df[COL_CT].astype(str).str.lower().str.startswith('y')
+    df['flag_hosp'] = df[COL_HOSP].astype(str).str.lower().str.startswith('y')
     df['rep_vec'] = pd.to_numeric(df[COL_REP], errors='coerce')
     df['geno'] = df[COL_GENO].map(geno_cat)
     df['flag_long'] = df['rep_vec'] >= 14

--- a/table_y.py
+++ b/table_y.py
@@ -3,16 +3,6 @@ from data_preprocessing import (
     TOTAL,
     MONO,
     COMBO,
-    COL_AGE,
-    COL_SEX,
-    COL_DIS,
-    COL_BASE,
-    COL_GC,
-    COL_VACC,
-    COL_CT,
-    COL_HOSP,
-    group_immuno,
-    parse_vacc,
     fmt_pct,
     chi_or_fisher,
     fmt_p,
@@ -20,33 +10,6 @@ from data_preprocessing import (
     fmt_range,
     cont_test,
 )
-
-
-def _add_flags(df: pd.DataFrame) -> pd.DataFrame:
-    df['flag_female'] = df[COL_SEX].astype(str).str.lower().str.startswith('f')
-    s = df[COL_DIS].astype(str).str.lower()
-    df['flag_malign'] = s.str.contains('m')
-    df['flag_autoimm'] = s.str.contains('a')
-    df['flag_transpl'] = s.str.contains('t')
-    base = df[COL_BASE].map(group_immuno)
-    df['flag_cd20'] = base == 'CD20'
-    df['flag_cart'] = base == 'CAR-T'
-    df['flag_hsct'] = base == 'HSCT'
-    df['flag_immuno_none'] = ~(df[['flag_cd20', 'flag_cart', 'flag_hsct']].any(axis=1)) | (base == 'none')
-    df['flag_gc'] = df[COL_GC].astype(str).str.lower().str.startswith('y')
-    vacc = df[COL_VACC].map(parse_vacc)
-    df['vacc_yes'] = vacc.map(lambda x: x[0] == 'Yes')
-    df['vacc_dose'] = vacc.map(lambda x: x[1])
-    df['flag_ct'] = df[COL_CT].astype(str).str.lower().str.startswith('y')
-    df['flag_hosp'] = df[COL_HOSP].astype(str).str.lower().str.startswith('y')
-    df['age_vec'] = pd.to_numeric(df[COL_AGE], errors='coerce')
-    df['dose_vec'] = pd.to_numeric(df['vacc_dose'], errors='coerce')
-    return df
-
-
-TOTAL = _add_flags(TOTAL)
-MONO = _add_flags(MONO)
-COMBO = _add_flags(COMBO)
 
 index = pd.MultiIndex.from_tuples(
     [


### PR DESCRIPTION
## Summary
- centralize flag creation by extending `add_flags_extended`
- rely on precomputed flags in `table_y`

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880a9065914833395a3458606f105e4