### PR TITLE
Fix table_z counts for exclusive categories

### DIFF
--- a/table_z.py
+++ b/table_z.py
@@ -3,6 +3,7 @@ from data_preprocessing import (
     TOTAL,
     MONO,
     COMBO,
+    COL_THERAPY,
     fmt_pct,
     fmt_iqr,
     fmt_range,
@@ -74,6 +75,8 @@ columns = [
 
 table_z = pd.DataFrame(index=index, columns=columns)
 
+TOTAL_104 = TOTAL[TOTAL[COL_THERAPY].astype(str).str.startswith(('m', 'c'))]
+
 
 def add_rate(row, ft, fm, fc):
     nt = int(ft.sum())
@@ -121,7 +124,7 @@ def build_table_z():
     for lab in labs:
         add_rate(
             ('Haematological malignancy, n (%)', lab),
-            TOTAL['heme'] == lab,
+            TOTAL_104['heme'] == lab,
             MONO['heme'] == lab,
             COMBO['heme'] == lab,
         )
@@ -138,28 +141,28 @@ def build_table_z():
     for lab in labs:
         add_rate(
             ('Autoimmune disease, n (%)', lab),
-            TOTAL['auto'] == lab,
+            TOTAL_104['auto'] == lab,
             MONO['auto'] == lab,
             COMBO['auto'] == lab,
         )
     for lab in ['Lung-TX', 'Kidney-TX']:
         add_rate(
             ('Transplantation, n (%)', lab),
-            TOTAL['trans'] == lab,
+            TOTAL_104['trans'] == lab,
             MONO['trans'] == lab,
             COMBO['trans'] == lab,
         )
     for lab in ['Haematological malignancy', 'Autoimmune disease', 'Transplantation']:
         add_rate(
             ('Disease group, n (%)', lab),
-            TOTAL['group'] == lab,
+            TOTAL_104['group'] == lab,
             MONO['group'] == lab,
             COMBO['group'] == lab,
         )
     for lab in ['None', 'Anti-CD-20', 'CAR-T']:
         add_rate(
             ('Immunosuppressive treatment, n (%)', lab),
-            TOTAL['immu'] == lab,
+            TOTAL_104['immu'] == lab,
             MONO['immu'] == lab,
             COMBO['immu'] == lab,
         )
@@ -182,7 +185,7 @@ def build_table_z():
     for lab in labs:
         add_rate(
             ('SARS-CoV-2 genotype, n (%)', lab),
-            TOTAL['geno'] == lab,
+            TOTAL_104['geno'] == lab,
             MONO['geno'] == lab,
             COMBO['geno'] == lab,
         )
@@ -199,7 +202,7 @@ def build_table_z():
         COMBO['flag_surv'],
     )
     for lab in ['None', 'Thrombocytopenia', 'Other']:
-        add_rate(('Adverse events, n (%)', lab), TOTAL['adv'] == lab, MONO['adv'] == lab, COMBO['adv'] == lab)
+        add_rate(('Adverse events, n (%)', lab), TOTAL_104['adv'] == lab, MONO['adv'] == lab, COMBO['adv'] == lab)
     return table_z
 
 


### PR DESCRIPTION
## Summary
- ensure table_z counts use the 104-row cohort when subrows are mutually exclusive
- update immunosuppressive treatment and related fields to sum correctly

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6880c0c5904883338dd1b404aff5f9e3