### PR TITLE
Use first 104 records for TOTAL

### DIFF
--- a/data_preprocessing.py
+++ b/data_preprocessing.py
@@ -31,7 +31,7 @@ def load_sheet(primary, alt):
         return pd.read_excel(FILE_PATH, sheet_name=alt)
 
 
-TOTAL = load_sheet('primary cohort, clean', 'primary cohort, n=104')
+TOTAL = load_sheet('primary cohort, clean', 'primary cohort, n=104').iloc[:104]
 MONO = load_sheet('subgroup mono', 'subgroup mono n=33')
 COMBO = load_sheet('subgroup combo', 'subgroup combo, n=57')
 for _df in (TOTAL, MONO, COMBO):

--- a/table_y.py
+++ b/table_y.py
@@ -3,7 +3,6 @@ from data_preprocessing import (
     TOTAL,
     MONO,
     COMBO,
-    COL_THERAPY,
     fmt_pct,
     chi_or_fisher,
     fmt_p,
@@ -48,8 +47,6 @@ table_y = pd.DataFrame(index=index, columns=columns)
 table_y_raw = pd.DataFrame(index=index, columns=columns)
 table_y.loc[('N =', '')] = [len(TOTAL), len(MONO), len(COMBO), '']
 table_y_raw.loc[('N =', '')] = [len(TOTAL), len(MONO), len(COMBO), None]
-
-TOTAL_104 = TOTAL[TOTAL[COL_THERAPY].astype(str).str.startswith(('m', 'c'))]
 
 
 def add_rate(row, flag_total, flag_mono, flag_combo):
@@ -106,8 +103,8 @@ def build_table_y():
     table_y_raw.loc[:] = None
     table_y.loc[('N =', '')] = [len(TOTAL), len(MONO), len(COMBO), '']
     table_y_raw.loc[('N =', '')] = [len(TOTAL), len(MONO), len(COMBO), None]
-    add_median_iqr(('Age, median (IQR)', ''), TOTAL_104['age_vec'], MONO['age_vec'], COMBO['age_vec'])
-    add_rate(('Female sex, n (%)', ''), TOTAL_104['flag_female'], MONO['flag_female'], COMBO['flag_female'])
+    add_median_iqr(('Age, median (IQR)', ''), TOTAL['age_vec'], MONO['age_vec'], COMBO['age_vec'])
+    add_rate(('Female sex, n (%)', ''), TOTAL['flag_female'], MONO['flag_female'], COMBO['flag_female'])
     table_y.loc[('Underlying conditions, n (%)', '')] = ''
     table_y_raw.loc[('Underlying conditions, n (%)', '')] = None
     pairs = [
@@ -116,7 +113,7 @@ def build_table_y():
         ('Transplantation', 'flag_transpl'),
     ]
     for lbl, col in pairs:
-        add_rate(('Underlying conditions, n (%)', lbl), TOTAL_104[col], MONO[col], COMBO[col])
+        add_rate(('Underlying conditions, n (%)', lbl), TOTAL[col], MONO[col], COMBO[col])
     table_y.loc[('Immunosuppressive treatment, n (%)', '')] = ''
     table_y_raw.loc[('Immunosuppressive treatment, n (%)', '')] = None
     pairs = [
@@ -126,28 +123,28 @@ def build_table_y():
         ('None', 'flag_immuno_none'),
     ]
     for lbl, col in pairs:
-        add_rate(('Immunosuppressive treatment, n (%)', lbl), TOTAL_104[col], MONO[col], COMBO[col])
-    add_rate(('Glucocorticoid use, n (%)', ''), TOTAL_104['flag_gc'], MONO['flag_gc'], COMBO['flag_gc'])
-    add_rate(('SARS-CoV-2 vaccination, n (%)', ''), TOTAL_104['vacc_yes'], MONO['vacc_yes'], COMBO['vacc_yes'])
+        add_rate(('Immunosuppressive treatment, n (%)', lbl), TOTAL[col], MONO[col], COMBO[col])
+    add_rate(('Glucocorticoid use, n (%)', ''), TOTAL['flag_gc'], MONO['flag_gc'], COMBO['flag_gc'])
+    add_rate(('SARS-CoV-2 vaccination, n (%)', ''), TOTAL['vacc_yes'], MONO['vacc_yes'], COMBO['vacc_yes'])
     add_mean_range(
         ('Mean Vaccination doses, n (range)', ''),
-        TOTAL_104['dose_vec'],
+        TOTAL['dose_vec'],
         MONO['dose_vec'],
         COMBO['dose_vec'],
     )
-    add_rate(('Thoracic CT changes, n (%)', ''), TOTAL_104['flag_ct'], MONO['flag_ct'], COMBO['flag_ct'])
+    add_rate(('Thoracic CT changes, n (%)', ''), TOTAL['flag_ct'], MONO['flag_ct'], COMBO['flag_ct'])
 
     table_y.loc[('Treatment setting\u00b9, n (%)', '')] = ''
     table_y_raw.loc[('Treatment setting\u00b9, n (%)', '')] = None
     add_rate(
         ('Treatment setting\u00b9, n (%)', 'Hospital'),
-        TOTAL_104['flag_hosp'],
+        TOTAL['flag_hosp'],
         MONO['flag_hosp'],
         COMBO['flag_hosp'],
     )
     add_rate(
         ('Treatment setting\u00b9, n (%)', 'Outpatient'),
-        ~TOTAL_104['flag_hosp'],
+        ~TOTAL['flag_hosp'],
         ~MONO['flag_hosp'],
         ~COMBO['flag_hosp'],
     )

--- a/table_z.py
+++ b/table_z.py
@@ -3,7 +3,6 @@ from data_preprocessing import (
     TOTAL,
     MONO,
     COMBO,
-    COL_THERAPY,
     fmt_pct,
     fmt_iqr,
     fmt_range,
@@ -77,8 +76,6 @@ columns = [
 table_z = pd.DataFrame(index=index, columns=columns)
 table_z.loc[('N =', '')] = [len(TOTAL), len(MONO), len(COMBO), '']
 
-TOTAL_104 = TOTAL[TOTAL[COL_THERAPY].astype(str).str.startswith(('m', 'c'))]
-
 
 def add_rate(row, ft, fm, fc):
     nt = int(ft.sum())
@@ -113,6 +110,7 @@ def add_range(row, vt, vm, vc):
 
 def build_table_z():
     table_z.loc[:] = None
+    table_z.loc[('N =', '')] = [len(TOTAL), len(MONO), len(COMBO), '']
     table_z.loc[('Haematological malignancy, n (%)', '')] = ''
     table_z.loc[('Autoimmune disease, n (%)', '')] = ''
     table_z.loc[('Transplantation, n (%)', '')] = ''
@@ -126,7 +124,7 @@ def build_table_z():
     for lab in labs:
         add_rate(
             ('Haematological malignancy, n (%)', lab),
-            TOTAL_104['heme'] == lab,
+            TOTAL['heme'] == lab,
             MONO['heme'] == lab,
             COMBO['heme'] == lab,
         )
@@ -143,28 +141,28 @@ def build_table_z():
     for lab in labs:
         add_rate(
             ('Autoimmune disease, n (%)', lab),
-            TOTAL_104['auto'] == lab,
+            TOTAL['auto'] == lab,
             MONO['auto'] == lab,
             COMBO['auto'] == lab,
         )
     for lab in ['Lung-TX', 'Kidney-TX']:
         add_rate(
             ('Transplantation, n (%)', lab),
-            TOTAL_104['trans'] == lab,
+            TOTAL['trans'] == lab,
             MONO['trans'] == lab,
             COMBO['trans'] == lab,
         )
     for lab in ['Haematological malignancy', 'Autoimmune disease', 'Transplantation']:
         add_rate(
             ('Disease group, n (%)', lab),
-            TOTAL_104['group'] == lab,
+            TOTAL['group'] == lab,
             MONO['group'] == lab,
             COMBO['group'] == lab,
         )
     for lab in ['None', 'Anti-CD-20', 'CAR-T']:
         add_rate(
             ('Immunosuppressive treatment, n (%)', lab),
-            TOTAL_104['immu'] == lab,
+            TOTAL['immu'] == lab,
             MONO['immu'] == lab,
             COMBO['immu'] == lab,
         )
@@ -187,7 +185,7 @@ def build_table_z():
     for lab in labs:
         add_rate(
             ('SARS-CoV-2 genotype, n (%)', lab),
-            TOTAL_104['geno'] == lab,
+            TOTAL['geno'] == lab,
             MONO['geno'] == lab,
             COMBO['geno'] == lab,
         )
@@ -204,7 +202,7 @@ def build_table_z():
         COMBO['flag_surv'],
     )
     for lab in ['None', 'Thrombocytopenia', 'Other']:
-        add_rate(('Adverse events, n (%)', lab), TOTAL_104['adv'] == lab, MONO['adv'] == lab, COMBO['adv'] == lab)
+        add_rate(('Adverse events, n (%)', lab), TOTAL['adv'] == lab, MONO['adv'] == lab, COMBO['adv'] == lab)
     return table_z
 
 


### PR DESCRIPTION
## Summary
- restrict TOTAL to first 104 rows of the primary worksheet
- remove TOTAL_104 from tables
- fix N counts in Table Z

## Testing
- `flake8`
- `pytest -q`
- manual runs of Table X, Y, Z


------
https://chatgpt.com/codex/tasks/task_e_6881f725a4508333a5c1444b6a0c9c37