### PR TITLE
Reduce duplicated table code

### DIFF
--- a/data_preprocessing.py
+++ b/data_preprocessing.py
@@ -232,6 +232,21 @@ def fmt_range(series: pd.Series) -> str:
     return f'{int(series.min())}-{int(series.max())}'
 
 
+def rate_calc(ft, fm, fc):
+    nt = int(ft.sum())
+    nm = int(fm.sum())
+    nc = int(fc.sum())
+    p = chi_or_fisher(nc, len(fc) - nc, nm, len(fm) - nm)
+    return nt, nm, nc, p
+
+
+def vec_calc(vt, vm, vc):
+    vt = pd.to_numeric(vt, errors='coerce').dropna()
+    vm = pd.to_numeric(vm, errors='coerce').dropna()
+    vc = pd.to_numeric(vc, errors='coerce').dropna()
+    return vt, vm, vc, cont_test(vm, vc)
+
+
 def add_flags_extended(df: pd.DataFrame) -> pd.DataFrame:
     df['age_vec'] = pd.to_numeric(df[COL_AGE], errors='coerce')
     df['flag_female'] = df[COL_SEX].astype(str).str.lower().str.startswith('f')

--- a/table_x.py
+++ b/table_x.py
@@ -9,12 +9,13 @@ from data_preprocessing import (
 
     parse_ext,
     fmt_pct,
-    chi_or_fisher,
     fmt_p,
     fmt_iqr,
 
     fmt_range,
     cont_test,
+    rate_calc,
+    chi_or_fisher,
 )
 
 
@@ -51,16 +52,12 @@ def build_table_x():
     ])
     t_x.loc[('N =', '')] = [len(TOTAL), len(MONO), len(COMBO), '']
 
-    def add_rate(row, ser_total, ser_mono, ser_combo):
-        t_x.at[row, 'Total'] = fmt_pct(int(ser_total.sum()), len(TOTAL))
-        t_x.at[row, 'Monotherapy'] = fmt_pct(int(ser_mono.sum()), len(MONO))
-        t_x.at[row, 'Combination'] = fmt_pct(int(ser_combo.sum()), len(COMBO))
-        if ser_total.sum():
-            a11 = int(ser_combo.sum())
-            a12 = len(ser_combo) - a11
-            a21 = int(ser_mono.sum())
-            a22 = len(ser_mono) - a21
-            p = chi_or_fisher(a11, a12, a21, a22)
+    def add_rate(row, st, sm, sc):
+        nt, nm, nc, p = rate_calc(st, sm, sc)
+        t_x.at[row, 'Total'] = fmt_pct(nt, len(TOTAL))
+        t_x.at[row, 'Monotherapy'] = fmt_pct(nm, len(MONO))
+        t_x.at[row, 'Combination'] = fmt_pct(nc, len(COMBO))
+        if st.sum():
             t_x.at[row, 'p-value'] = fmt_p(p)
         else:
             t_x.at[row, 'p-value'] = ''
@@ -169,19 +166,13 @@ def build_table_x_raw():
         'p-value',
     ])
 
-    def add(row, ser_total, ser_mono, ser_combo):
-        nt = int(ser_total.sum())
-        nm = int(ser_mono.sum())
-        nc = int(ser_combo.sum())
+    def add(row, st, sm, sc):
+        nt, nm, nc, p = rate_calc(st, sm, sc)
         raw.at[row, 'Total'] = nt
         raw.at[row, 'Monotherapy'] = nm
         raw.at[row, 'Combination'] = nc
         if nt:
-            a11 = nc
-            a12 = len(ser_combo) - nc
-            a21 = nm
-            a22 = len(ser_mono) - nm
-            raw.at[row, 'p-value'] = chi_or_fisher(a11, a12, a21, a22)
+            raw.at[row, 'p-value'] = p
 
     labels = [
         'Standard 5-day Paxlovid',

--- a/table_z.py
+++ b/table_z.py
@@ -6,9 +6,9 @@ from data_preprocessing import (
     fmt_pct,
     fmt_iqr,
     fmt_range,
-    chi_or_fisher,
     fmt_p,
-    cont_test,
+    rate_calc,
+    vec_calc,
 )
 
 index = pd.MultiIndex.from_tuples(
@@ -78,34 +78,27 @@ table_z.loc[('N =', '')] = [len(TOTAL), len(MONO), len(COMBO), '']
 
 
 def add_rate(row, ft, fm, fc):
-    nt = int(ft.sum())
-    nm = int(fm.sum())
-    nc = int(fc.sum())
+    nt, nm, nc, p = rate_calc(ft, fm, fc)
     table_z.at[row, 'Total'] = fmt_pct(nt, len(ft))
     table_z.at[row, 'Monotherapy'] = fmt_pct(nm, len(fm))
     table_z.at[row, 'Combination'] = fmt_pct(nc, len(fc))
-    p = chi_or_fisher(nc, len(fc) - nc, nm, len(fm) - nm)
     table_z.at[row, 'p-value'] = fmt_p(p)
 
 
 def add_median_iqr(row, vt, vm, vc):
-    vt = pd.to_numeric(vt, errors='coerce').dropna()
-    vm = pd.to_numeric(vm, errors='coerce').dropna()
-    vc = pd.to_numeric(vc, errors='coerce').dropna()
+    vt, vm, vc, p = vec_calc(vt, vm, vc)
     table_z.at[row, 'Total'] = fmt_iqr(vt)
     table_z.at[row, 'Monotherapy'] = fmt_iqr(vm)
     table_z.at[row, 'Combination'] = fmt_iqr(vc)
-    table_z.at[row, 'p-value'] = fmt_p(cont_test(vm, vc))
+    table_z.at[row, 'p-value'] = fmt_p(p)
 
 
 def add_range(row, vt, vm, vc):
-    vt = pd.to_numeric(vt, errors='coerce').dropna()
-    vm = pd.to_numeric(vm, errors='coerce').dropna()
-    vc = pd.to_numeric(vc, errors='coerce').dropna()
+    vt, vm, vc, p = vec_calc(vt, vm, vc)
     table_z.at[row, 'Total'] = fmt_range(vt)
     table_z.at[row, 'Monotherapy'] = fmt_range(vm)
     table_z.at[row, 'Combination'] = fmt_range(vc)
-    table_z.at[row, 'p-value'] = fmt_p(cont_test(vm, vc))
+    table_z.at[row, 'p-value'] = fmt_p(p)
 
 
 def build_table_z():


### PR DESCRIPTION
## Summary
- add `rate_calc` and `vec_calc` helpers to centralize table summaries
- refactor table scripts to reuse these helpers

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881fd6f670c8333a3e4b7675cee99dd