### PR TITLE
Improve table titles and p‑value display

### DIFF
--- a/code.md
+++ b/code.md
@@ -957,15 +957,12 @@ def flag(series, val):
     return series.astype(str).str.lower().str.startswith(val)
 
 
-index = pd.MultiIndex.from_tuples(
-    [
-        ('SARS-CoV-2 Persistence\u00b9, n (%)', ''),
-        ('All-cause mortality\u00b2, n (%)', ''),
-        ('SARS-CoV-2-related mortality\u00b3, n (%)', ''),
-        ('AE\u2074, n (%)', ''),
-    ],
-    names=['Outcomes', ''],
-)
+index = [
+    'SARS-CoV-2 Persistence\u00b9, n (%)',
+    'All-cause mortality\u00b2, n (%)',
+    'SARS-CoV-2-related mortality\u00b3, n (%)',
+    'AE\u2074, n (%)',
+]
 
 
 def build_table_B():

--- a/code.md
+++ b/code.md
@@ -473,8 +473,9 @@ def build_table_x():
     t_x.at[('Duration', 'Duration range, days'), 'Combination'] = fmt_range(days_c)
     t_x.loc[('Duration', '')] = ''
     p_dur = cont_test(days_m.dropna(), days_c.dropna())
-    t_x.at[('Duration', 'Median duration, days (IQR)'), 'p-value'] = fmt_p(p_dur)
-    t_x.at[('Duration', 'Duration range, days'), 'p-value'] = fmt_p(p_dur)
+    t_x.at[('Duration', ''), 'p-value'] = fmt_p(p_dur)
+    t_x.at[('Duration', 'Median duration, days (IQR)'), 'p-value'] = ''
+    t_x.at[('Duration', 'Duration range, days'), 'p-value'] = ''
     foot = (
         '- NMV-r, nirmatrelvir-ritonavir.\n'
         '1: Any treatment administered prior to extended nirmatrelvir-ritonavir, '
@@ -704,18 +705,31 @@ def build_table_y():
 
     table_y.loc[('Treatment setting\u00b9, n (%)', '')] = ''
     table_y_raw.loc[('Treatment setting\u00b9, n (%)', '')] = None
-    add_rate(
+    nt, nm, nc, p_set = fill_rate(
+        table_y,
         ('Treatment setting\u00b9, n (%)', 'Hospital'),
         TOTAL['flag_hosp'],
         MONO['flag_hosp'],
         COMBO['flag_hosp'],
     )
-    add_rate(
+    table_y_raw.at[('Treatment setting\u00b9, n (%)', 'Hospital'), 'Total'] = nt
+    table_y_raw.at[('Treatment setting\u00b9, n (%)', 'Hospital'), 'Monotherapy'] = nm
+    table_y_raw.at[('Treatment setting\u00b9, n (%)', 'Hospital'), 'Combination'] = nc
+    table_y_raw.at[('Treatment setting\u00b9, n (%)', 'Hospital'), 'p-value'] = p_set
+    nt2, nm2, nc2, _ = fill_rate(
+        table_y,
         ('Treatment setting\u00b9, n (%)', 'Outpatient'),
         ~TOTAL['flag_hosp'],
         ~MONO['flag_hosp'],
         ~COMBO['flag_hosp'],
     )
+    table_y_raw.at[('Treatment setting\u00b9, n (%)', 'Outpatient'), 'Total'] = nt2
+    table_y_raw.at[('Treatment setting\u00b9, n (%)', 'Outpatient'), 'Monotherapy'] = nm2
+    table_y_raw.at[('Treatment setting\u00b9, n (%)', 'Outpatient'), 'Combination'] = nc2
+    table_y_raw.at[('Treatment setting\u00b9, n (%)', 'Outpatient'), 'p-value'] = None
+    table_y.at[('Treatment setting\u00b9, n (%)', 'Hospital'), 'p-value'] = ''
+    table_y.at[('Treatment setting\u00b9, n (%)', 'Outpatient'), 'p-value'] = ''
+    table_y.at[('Treatment setting\u00b9, n (%)', ''), 'p-value'] = fmt_p(p_set)
     foot = (
         '- NMV-r, nirmatrelvir-ritonavir.\n'
         '1: Treatment setting where prolonged NMV-r was administered.'
@@ -931,7 +945,7 @@ def build_table_z():
 
 
 if __name__ == '__main__':
-    print('Table Z')
+    print('Table Z. Detailed Patient Characteristics.')
     print(build_table_z().to_string())
 
 COL_ERAD = 'eradication outcome successful\n[yes / no]'

--- a/run_tables.py
+++ b/run_tables.py
@@ -28,7 +28,7 @@ def cont_test_method(v1, v2):
         n2 = len(v2)
         df = (s1 / n1 + s2 / n2) ** 2 / ((s1 / n1) ** 2 / (n1 - 1) + (s2 / n2) ** 2 / (n2 - 1))
         return f"t-test df={int(round(df))}"
-    return "MWU"
+    return "Mann-Whitney-U"
 
 
 def tests_table_x():
@@ -375,10 +375,10 @@ def main():
     out_tab = "tables.md"
     clean(out_tab)
     with open(out_tab, "w") as f:
-        f.write(section("Table X", t1, m1))
-        f.write(section("Table Y", t2, m2))
-        f.write(section("Table Z", t3, m3))
-        f.write(section("Table B", t4, m4))
+        f.write(section("Table X. Treatment Approach", t1, m1))
+        f.write(section("Table Y. Demographics and Clinical Characteristics", t2, m2))
+        f.write(section("Table Z. Detailed Patient Characteristics", t3, m3))
+        f.write(section("Table B. Outcomes in all cohorts", t4, m4))
     out_code = "code.md"
     clean(out_code)
     with open(out_code, "w") as f:

--- a/table_B.py
+++ b/table_B.py
@@ -10,15 +10,12 @@ def flag(series, val):
     return series.astype(str).str.lower().str.startswith(val)
 
 
-index = pd.MultiIndex.from_tuples(
-    [
-        ('SARS-CoV-2 Persistence\u00b9, n (%)', ''),
-        ('All-cause mortality\u00b2, n (%)', ''),
-        ('SARS-CoV-2-related mortality\u00b3, n (%)', ''),
-        ('AE\u2074, n (%)', ''),
-    ],
-    names=['Outcomes', ''],
-)
+index = [
+    'SARS-CoV-2 Persistence\u00b9, n (%)',
+    'All-cause mortality\u00b2, n (%)',
+    'SARS-CoV-2-related mortality\u00b3, n (%)',
+    'AE\u2074, n (%)',
+]
 
 
 def build_table_B():

--- a/table_x.py
+++ b/table_x.py
@@ -118,8 +118,9 @@ def build_table_x():
     t_x.at[('Duration', 'Duration range, days'), 'Combination'] = fmt_range(days_c)
     t_x.loc[('Duration', '')] = ''
     p_dur = cont_test(days_m.dropna(), days_c.dropna())
-    t_x.at[('Duration', 'Median duration, days (IQR)'), 'p-value'] = fmt_p(p_dur)
-    t_x.at[('Duration', 'Duration range, days'), 'p-value'] = fmt_p(p_dur)
+    t_x.at[('Duration', ''), 'p-value'] = fmt_p(p_dur)
+    t_x.at[('Duration', 'Median duration, days (IQR)'), 'p-value'] = ''
+    t_x.at[('Duration', 'Duration range, days'), 'p-value'] = ''
     foot = (
         '- NMV-r, nirmatrelvir-ritonavir.\n'
         '1: Any treatment administered prior to extended nirmatrelvir-ritonavir, '

--- a/table_y.py
+++ b/table_y.py
@@ -6,6 +6,7 @@ from data_preprocessing import (
     fill_rate,
     fill_median_iqr,
     fill_mean_range,
+    fmt_p,
 )
 
 index = pd.MultiIndex.from_tuples(
@@ -108,18 +109,31 @@ def build_table_y():
 
     table_y.loc[('Treatment setting\u00b9, n (%)', '')] = ''
     table_y_raw.loc[('Treatment setting\u00b9, n (%)', '')] = None
-    add_rate(
+    nt, nm, nc, p_set = fill_rate(
+        table_y,
         ('Treatment setting\u00b9, n (%)', 'Hospital'),
         TOTAL['flag_hosp'],
         MONO['flag_hosp'],
         COMBO['flag_hosp'],
     )
-    add_rate(
+    table_y_raw.at[('Treatment setting\u00b9, n (%)', 'Hospital'), 'Total'] = nt
+    table_y_raw.at[('Treatment setting\u00b9, n (%)', 'Hospital'), 'Monotherapy'] = nm
+    table_y_raw.at[('Treatment setting\u00b9, n (%)', 'Hospital'), 'Combination'] = nc
+    table_y_raw.at[('Treatment setting\u00b9, n (%)', 'Hospital'), 'p-value'] = p_set
+    nt2, nm2, nc2, _ = fill_rate(
+        table_y,
         ('Treatment setting\u00b9, n (%)', 'Outpatient'),
         ~TOTAL['flag_hosp'],
         ~MONO['flag_hosp'],
         ~COMBO['flag_hosp'],
     )
+    table_y_raw.at[('Treatment setting\u00b9, n (%)', 'Outpatient'), 'Total'] = nt2
+    table_y_raw.at[('Treatment setting\u00b9, n (%)', 'Outpatient'), 'Monotherapy'] = nm2
+    table_y_raw.at[('Treatment setting\u00b9, n (%)', 'Outpatient'), 'Combination'] = nc2
+    table_y_raw.at[('Treatment setting\u00b9, n (%)', 'Outpatient'), 'p-value'] = None
+    table_y.at[('Treatment setting\u00b9, n (%)', 'Hospital'), 'p-value'] = ''
+    table_y.at[('Treatment setting\u00b9, n (%)', 'Outpatient'), 'p-value'] = ''
+    table_y.at[('Treatment setting\u00b9, n (%)', ''), 'p-value'] = fmt_p(p_set)
     foot = (
         '- NMV-r, nirmatrelvir-ritonavir.\n'
         '1: Treatment setting where prolonged NMV-r was administered.'

--- a/table_z.py
+++ b/table_z.py
@@ -185,5 +185,5 @@ def build_table_z():
 
 
 if __name__ == '__main__':
-    print('Table Z')
+    print('Table Z. Detailed Patient Characteristics.')
     print(build_table_z().to_string())

--- a/tables.md
+++ b/tables.md
@@ -108,12 +108,12 @@
 
 # Table B. Outcomes in all cohorts
 
-| row                                  | subrow   | Total      | Monotherapy   | Combination   |   p-value | test   |
-|:-------------------------------------|:---------|:-----------|:--------------|:--------------|----------:|:-------|
-| SARS-CoV-2 Persistence¹, n (%)       |          | 14 (13.5%) | 5 (15.2%)     | 6 (10.5%)     |     0.523 | Fisher |
-| All-cause mortality², n (%)          |          | 10 (9.6%)  | 2 (6.1%)      | 4 (7.0%)      |     1     | Fisher |
-| SARS-CoV-2-related mortality³, n (%) |          | 5 (4.8%)   | 1 (3.0%)      | 2 (3.5%)      |     1     | Fisher |
-| AE⁴, n (%)                           |          | 6 (5.8%)   | 1 (3.0%)      | 5 (8.8%)      |     0.409 | Fisher |
+| row                                  | Total      | Monotherapy   | Combination   |   p-value | test   |
+|:-------------------------------------|:-----------|:--------------|:--------------|----------:|:-------|
+| SARS-CoV-2 Persistence¹, n (%)       | 14 (13.5%) | 5 (15.2%)     | 6 (10.5%)     |     0.523 | Fisher |
+| All-cause mortality², n (%)          | 10 (9.6%)  | 2 (6.1%)      | 4 (7.0%)      |     1     | Fisher |
+| SARS-CoV-2-related mortality³, n (%) | 5 (4.8%)   | 1 (3.0%)      | 2 (3.5%)      |     1     | Fisher |
+| AE⁴, n (%)                           | 6 (5.8%)   | 1 (3.0%)      | 5 (8.8%)      |     0.409 | Fisher |
 
 Abbreviations: AE, adverse event. n/a, not available, i.e. not reported. NAAT, nucleic acid amplification test. NMV-r, nirmatrelvir-ritonavir. TAC, Tacrolimus.
 1: defined as subjects with parameter “eradication outcome successful: no”

--- a/tables.md
+++ b/tables.md
@@ -1,112 +1,112 @@
-# Table X
+# Table X. Treatment Approach
 
-| row                        | subrow                      | Total      | Monotherapy   | Combination   | p-value   | test      |
-|:---------------------------|:----------------------------|:-----------|:--------------|:--------------|:----------|:----------|
-| N =                        |                             | 104        | 33            | 57            |           |           |
-| First-line therapy¹, n (%) |                             |            |               |               |           |           |
-|                            | Remdesivir                  | 36 (34.6%) | 13 (39.4%)    | 21 (36.8%)    | 0.988     | Chi2 df=1 |
-|                            | Molnupiravir                | 14 (13.5%) | 5 (15.2%)     | 9 (15.8%)     | 1.000     | Chi2 df=1 |
-|                            | Standard 5-day Paxlovid     | 31 (29.8%) | 5 (15.2%)     | 25 (43.9%)    | 0.011     | Chi2 df=1 |
-|                            | Other antivirals            | 11 (10.6%) | 4 (12.1%)     | 7 (12.3%)     | 1.000     | Fisher    |
-|                            | None                        | 49 (47.1%) | 13 (39.4%)    | 24 (42.1%)    | 0.976     | Chi2 df=1 |
-| Last line therapy², n (%)  |                             |            |               |               | <0.001    | Chi2 df=1 |
-|                            | Combination therapy         | 63 (60.6%) | 0 (0.0%)      | 57 (100.0%)   |           |           |
-|                            | Monotherapy                 | 41 (39.4%) | 33 (100.0%)   | 0 (0.0%)      |           |           |
-| Treatment courses, n (%)   |                             |            |               |               | 1.000     | Fisher    |
-|                            | Single prolonged course     | 99 (95.2%) | 31 (93.9%)    | 54 (94.7%)    |           |           |
-|                            | Multiple courses            | 5 (4.8%)   | 2 (6.1%)      | 3 (5.3%)      |           |           |
-| Duration                   |                             |            |               |               |           | MWU       |
-|                            | Median duration, days (IQR) | 10 (10-15) | 10 (10-15)    | 10 (10-14)    | 0.206     |           |
-|                            | Duration range, days        | 5-61       | 7-36          | 5-61          | 0.206     |           |
+| row                        | subrow                      | Total      | Monotherapy   | Combination   | p-value   | test           |
+|:---------------------------|:----------------------------|:-----------|:--------------|:--------------|:----------|:---------------|
+| N =                        |                             | 104        | 33            | 57            |           |                |
+| First-line therapy¹, n (%) |                             |            |               |               |           |                |
+|                            | Remdesivir                  | 36 (34.6%) | 13 (39.4%)    | 21 (36.8%)    | 0.988     | Chi2 df=1      |
+|                            | Molnupiravir                | 14 (13.5%) | 5 (15.2%)     | 9 (15.8%)     | 1.000     | Chi2 df=1      |
+|                            | Standard 5-day Paxlovid     | 31 (29.8%) | 5 (15.2%)     | 25 (43.9%)    | 0.011     | Chi2 df=1      |
+|                            | Other antivirals            | 11 (10.6%) | 4 (12.1%)     | 7 (12.3%)     | 1.000     | Fisher         |
+|                            | None                        | 49 (47.1%) | 13 (39.4%)    | 24 (42.1%)    | 0.976     | Chi2 df=1      |
+| Last line therapy², n (%)  |                             |            |               |               | <0.001    | Chi2 df=1      |
+|                            | Combination therapy         | 63 (60.6%) | 0 (0.0%)      | 57 (100.0%)   |           |                |
+|                            | Monotherapy                 | 41 (39.4%) | 33 (100.0%)   | 0 (0.0%)      |           |                |
+| Treatment courses, n (%)   |                             |            |               |               | 1.000     | Fisher         |
+|                            | Single prolonged course     | 99 (95.2%) | 31 (93.9%)    | 54 (94.7%)    |           |                |
+|                            | Multiple courses            | 5 (4.8%)   | 2 (6.1%)      | 3 (5.3%)      |           |                |
+| Duration                   |                             |            |               |               | 0.206     | Mann-Whitney-U |
+|                            | Median duration, days (IQR) | 10 (10-15) | 10 (10-15)    | 10 (10-14)    |           |                |
+|                            | Duration range, days        | 5-61       | 7-36          | 5-61          |           |                |
 
 - NMV-r, nirmatrelvir-ritonavir.
 1: Any treatment administered prior to extended nirmatrelvir-ritonavir, including standard 5-day Paxlovid courses with or without other antivirals.
 2: Extended nirmatrelvir-ritonavir regimens (with or without concurrent antivirals) when no subsequent antiviral therapy was administered.
 
-# Table Y
+# Table Y. Demographics and Clinical Characteristics
 
-| row                                | subrow                   | Total      | Monotherapy   | Combination   | p-value   | test      |
-|:-----------------------------------|:-------------------------|:-----------|:--------------|:--------------|:----------|:----------|
-| N =                                |                          | 104        | 33            | 57            |           |           |
-| Age, median (IQR)                  |                          | 66 (58-73) | 63 (55-71)    | 67 (59-76)    | 0.061     | MWU       |
-| Female sex, n (%)                  |                          | 35 (33.7%) | 11 (33.3%)    | 21 (36.8%)    | 0.915     | Chi2 df=1 |
-| Underlying conditions, n (%)       |                          |            |               |               |           |           |
-|                                    | Hematological malignancy | 93 (89.4%) | 28 (84.8%)    | 53 (93.0%)    | 0.279     | Fisher    |
-|                                    | Autoimmune               | 11 (10.6%) | 4 (12.1%)     | 4 (7.0%)      | 0.458     | Fisher    |
-|                                    | Transplantation          | 4 (3.8%)   | 3 (9.1%)      | 1 (1.8%)      | 0.138     | Fisher    |
-| Immunosuppressive treatment, n (%) |                          |            |               |               |           |           |
-|                                    | Anti-CD20                | 77 (74.0%) | 23 (69.7%)    | 46 (80.7%)    | 0.352     | Chi2 df=1 |
-|                                    | CAR-T                    | 3 (2.9%)   | 0 (0.0%)      | 3 (5.3%)      | 0.296     | Fisher    |
-|                                    | HSCT                     | 3 (2.9%)   | 2 (6.1%)      | 1 (1.8%)      | 0.552     | Fisher    |
-|                                    | None                     | 21 (20.2%) | 8 (24.2%)     | 7 (12.3%)     | 0.240     | Chi2 df=1 |
-| Glucocorticoid use, n (%)          |                          | 47 (45.2%) | 13 (39.4%)    | 29 (50.9%)    | 0.405     | Chi2 df=1 |
-| SARS-CoV-2 vaccination, n (%)      |                          | 95 (91.3%) | 30 (90.9%)    | 53 (93.0%)    | 0.704     | Fisher    |
-| Mean Vaccination doses, n (range)  |                          | 3.3 (2-8)  | 3.3 (2-6)     | 3.3 (2-8)     | 0.651     | MWU       |
-| Thoracic CT changes, n (%)         |                          | 62 (59.6%) | 17 (51.5%)    | 38 (66.7%)    | 0.231     | Chi2 df=1 |
-| Treatment setting¹, n (%)          |                          |            |               |               |           | Chi2 df=1 |
-|                                    | Hospital                 | 55 (52.9%) | 17 (51.5%)    | 33 (57.9%)    | 0.714     |           |
-|                                    | Outpatient               | 49 (47.1%) | 16 (48.5%)    | 24 (42.1%)    | 0.714     |           |
+| row                                | subrow                   | Total      | Monotherapy   | Combination   | p-value   | test           |
+|:-----------------------------------|:-------------------------|:-----------|:--------------|:--------------|:----------|:---------------|
+| N =                                |                          | 104        | 33            | 57            |           |                |
+| Age, median (IQR)                  |                          | 66 (58-73) | 63 (55-71)    | 67 (59-76)    | 0.061     | Mann-Whitney-U |
+| Female sex, n (%)                  |                          | 35 (33.7%) | 11 (33.3%)    | 21 (36.8%)    | 0.915     | Chi2 df=1      |
+| Underlying conditions, n (%)       |                          |            |               |               |           |                |
+|                                    | Hematological malignancy | 93 (89.4%) | 28 (84.8%)    | 53 (93.0%)    | 0.279     | Fisher         |
+|                                    | Autoimmune               | 11 (10.6%) | 4 (12.1%)     | 4 (7.0%)      | 0.458     | Fisher         |
+|                                    | Transplantation          | 4 (3.8%)   | 3 (9.1%)      | 1 (1.8%)      | 0.138     | Fisher         |
+| Immunosuppressive treatment, n (%) |                          |            |               |               |           |                |
+|                                    | Anti-CD20                | 77 (74.0%) | 23 (69.7%)    | 46 (80.7%)    | 0.352     | Chi2 df=1      |
+|                                    | CAR-T                    | 3 (2.9%)   | 0 (0.0%)      | 3 (5.3%)      | 0.296     | Fisher         |
+|                                    | HSCT                     | 3 (2.9%)   | 2 (6.1%)      | 1 (1.8%)      | 0.552     | Fisher         |
+|                                    | None                     | 21 (20.2%) | 8 (24.2%)     | 7 (12.3%)     | 0.240     | Chi2 df=1      |
+| Glucocorticoid use, n (%)          |                          | 47 (45.2%) | 13 (39.4%)    | 29 (50.9%)    | 0.405     | Chi2 df=1      |
+| SARS-CoV-2 vaccination, n (%)      |                          | 95 (91.3%) | 30 (90.9%)    | 53 (93.0%)    | 0.704     | Fisher         |
+| Mean Vaccination doses, n (range)  |                          | 3.3 (2-8)  | 3.3 (2-6)     | 3.3 (2-8)     | 0.651     | Mann-Whitney-U |
+| Thoracic CT changes, n (%)         |                          | 62 (59.6%) | 17 (51.5%)    | 38 (66.7%)    | 0.231     | Chi2 df=1      |
+| Treatment setting¹, n (%)          |                          |            |               |               | 0.714     | Chi2 df=1      |
+|                                    | Hospital                 | 55 (52.9%) | 17 (51.5%)    | 33 (57.9%)    |           |                |
+|                                    | Outpatient               | 49 (47.1%) | 16 (48.5%)    | 24 (42.1%)    |           |                |
 
 - NMV-r, nirmatrelvir-ritonavir.
 1: Treatment setting where prolonged NMV-r was administered.
 
-# Table Z
+# Table Z. Detailed Patient Characteristics
 
-| row                                                     | subrow                          | Total       | Monotherapy   | Combination   | p-value   | test      |
-|:--------------------------------------------------------|:--------------------------------|:------------|:--------------|:--------------|:----------|:----------|
-| N =                                                     |                                 | 104         | 33            | 57            |           |           |
-| Age, median (IQR)                                       |                                 | 66 (58-73)  | 63 (55-71)    | 67 (59-76)    | 0.061     | MWU       |
-| Sex (female), n (%)                                     |                                 | 35 (33.7%)  | 11 (33.3%)    | 21 (36.8%)    | 0.915     | Chi2 df=1 |
-| Haematological malignancy, n (%)                        |                                 |             |               |               |           |           |
-|                                                         | Other                           | 20 (19.2%)  | 8 (24.2%)     | 10 (17.5%)    | 0.623     | Chi2 df=1 |
-|                                                         | DLBCL                           | 14 (13.5%)  | 1 (3.0%)      | 11 (19.3%)    | 0.050     | Fisher    |
-|                                                         | ALL                             | 6 (5.8%)    | 5 (15.2%)     | 1 (1.8%)      | 0.024     | Fisher    |
-|                                                         | CLL                             | 6 (5.8%)    | 0 (0.0%)      | 5 (8.8%)      | 0.154     | Fisher    |
-|                                                         | AML                             | 3 (2.9%)    | 2 (6.1%)      | 1 (1.8%)      | 0.552     | Fisher    |
-|                                                         | FL                              | 32 (30.8%)  | 9 (27.3%)     | 20 (35.1%)    | 0.596     | Chi2 df=1 |
-|                                                         | NHL                             | 16 (15.4%)  | 6 (18.2%)     | 8 (14.0%)     | 0.825     | Chi2 df=1 |
-|                                                         | MM                              | 4 (3.8%)    | 0 (0.0%)      | 0 (0.0%)      | 1.000     | Fisher    |
-|                                                         | Mixed                           | 3 (2.9%)    | 2 (6.1%)      | 1 (1.8%)      | 0.552     | Fisher    |
-| Autoimmune disease, n (%)                               |                                 |             |               |               |           |           |
-|                                                         | MCTD                            | 1 (1.0%)    | 0 (0.0%)      | 1 (1.8%)      | 1.000     | Fisher    |
-|                                                         | RA                              | 1 (1.0%)    | 1 (3.0%)      | 0 (0.0%)      | 0.367     | Fisher    |
-|                                                         | CREST                           | 1 (1.0%)    | 0 (0.0%)      | 0 (0.0%)      | 1.000     | Fisher    |
-|                                                         | MS                              | 2 (1.9%)    | 0 (0.0%)      | 1 (1.8%)      | 1.000     | Fisher    |
-|                                                         | SSc                             | 1 (1.0%)    | 1 (3.0%)      | 0 (0.0%)      | 0.367     | Fisher    |
-|                                                         | Colitis ulcerosa                | 0 (0.0%)    | 0 (0.0%)      | 0 (0.0%)      | 1.000     | Fisher    |
-|                                                         | Glomerulonephritis              | 0 (0.0%)    | 0 (0.0%)      | 0 (0.0%)      | 1.000     | Fisher    |
-|                                                         | NMDA-encephalitis               | 1 (1.0%)    | 0 (0.0%)      | 1 (1.8%)      | 1.000     | Fisher    |
-| Transplantation, n (%)                                  |                                 |             |               |               |           |           |
-|                                                         | LT                              | 2 (1.9%)    | 2 (6.1%)      | 0 (0.0%)      | 0.132     | Fisher    |
-|                                                         | KT                              | 2 (1.9%)    | 1 (3.0%)      | 1 (1.8%)      | 1.000     | Fisher    |
-| Disease group, n (%)                                    |                                 |             |               |               |           |           |
-|                                                         | Haematological malignancy       | 93 (89.4%)  | 28 (84.8%)    | 53 (93.0%)    | 0.279     | Fisher    |
-|                                                         | Autoimmune disease              | 7 (6.7%)    | 2 (6.1%)      | 3 (5.3%)      | 1.000     | Fisher    |
-|                                                         | Transplantation                 | 4 (3.8%)    | 3 (9.1%)      | 1 (1.8%)      | 0.138     | Fisher    |
-| Immunosuppressive treatment, n (%)                      |                                 |             |               |               |           |           |
-|                                                         | None                            | 24 (23.1%)  | 10 (30.3%)    | 8 (14.0%)     | 0.113     | Chi2 df=1 |
-|                                                         | Anti-CD-20                      | 77 (74.0%)  | 23 (69.7%)    | 46 (80.7%)    | 0.352     | Chi2 df=1 |
-|                                                         | CAR-T                           | 3 (2.9%)    | 0 (0.0%)      | 3 (5.3%)      | 0.296     | Fisher    |
-| Glucocorticoid use, n (%)                               |                                 | 47 (45.2%)  | 13 (39.4%)    | 29 (50.9%)    | 0.405     | Chi2 df=1 |
-| SARS-CoV-2 vaccination, n (%)                           |                                 | 95 (91.3%)  | 30 (90.9%)    | 53 (93.0%)    | 0.704     | Fisher    |
-| Number of vaccine doses, n (range)                      |                                 | 2-8         | 2-6           | 2-8           | 0.651     | MWU       |
-| Thoracic CT changes, n (%)                              |                                 | 62 (59.6%)  | 17 (51.5%)    | 38 (66.7%)    | 0.231     | Chi2 df=1 |
-| Duration of SARS-CoV-2 replication (days), median (IQR) |                                 | 64 (33-120) | 79 (33-135)   | 71 (38-116)   | 0.766     | MWU       |
-| SARS-CoV-2 genotype, n (%)                              |                                 |             |               |               |           |           |
-|                                                         | BA.5-derived Omicron subvariant | 31 (29.8%)  | 6 (18.2%)     | 21 (36.8%)    | 0.105     | Chi2 df=1 |
-|                                                         | BA.2-derived Omicron subvariant | 8 (7.7%)    | 4 (12.1%)     | 4 (7.0%)      | 0.458     | Fisher    |
-|                                                         | BA.1-derived Omicron subvariant | 9 (8.7%)    | 5 (15.2%)     | 4 (7.0%)      | 0.279     | Fisher    |
-|                                                         | Other                           | 56 (53.8%)  | 18 (54.5%)    | 28 (49.1%)    | 0.782     | Chi2 df=1 |
-| Prolonged viral shedding (≥ 14 days), n (%)             |                                 | 90 (86.5%)  | 33 (100.0%)   | 57 (100.0%)   | 1.000     | Fisher    |
-| Survival, n (%)                                         |                                 | 94 (90.4%)  | 31 (93.9%)    | 53 (93.0%)    | 1.000     | Fisher    |
-| Adverse events, n (%)                                   |                                 |             |               |               |           |           |
-|                                                         | None                            | 98 (94.2%)  | 32 (97.0%)    | 52 (91.2%)    | 0.409     | Fisher    |
-|                                                         | Thrombocytopenia                | 1 (1.0%)    | 0 (0.0%)      | 1 (1.8%)      | 1.000     | Fisher    |
-|                                                         | Other                           | 5 (4.8%)    | 1 (3.0%)      | 4 (7.0%)      | 0.648     | Fisher    |
+| row                                                     | subrow                          | Total       | Monotherapy   | Combination   | p-value   | test           |
+|:--------------------------------------------------------|:--------------------------------|:------------|:--------------|:--------------|:----------|:---------------|
+| N =                                                     |                                 | 104         | 33            | 57            |           |                |
+| Age, median (IQR)                                       |                                 | 66 (58-73)  | 63 (55-71)    | 67 (59-76)    | 0.061     | Mann-Whitney-U |
+| Sex (female), n (%)                                     |                                 | 35 (33.7%)  | 11 (33.3%)    | 21 (36.8%)    | 0.915     | Chi2 df=1      |
+| Haematological malignancy, n (%)                        |                                 |             |               |               |           |                |
+|                                                         | Other                           | 20 (19.2%)  | 8 (24.2%)     | 10 (17.5%)    | 0.623     | Chi2 df=1      |
+|                                                         | DLBCL                           | 14 (13.5%)  | 1 (3.0%)      | 11 (19.3%)    | 0.050     | Fisher         |
+|                                                         | ALL                             | 6 (5.8%)    | 5 (15.2%)     | 1 (1.8%)      | 0.024     | Fisher         |
+|                                                         | CLL                             | 6 (5.8%)    | 0 (0.0%)      | 5 (8.8%)      | 0.154     | Fisher         |
+|                                                         | AML                             | 3 (2.9%)    | 2 (6.1%)      | 1 (1.8%)      | 0.552     | Fisher         |
+|                                                         | FL                              | 32 (30.8%)  | 9 (27.3%)     | 20 (35.1%)    | 0.596     | Chi2 df=1      |
+|                                                         | NHL                             | 16 (15.4%)  | 6 (18.2%)     | 8 (14.0%)     | 0.825     | Chi2 df=1      |
+|                                                         | MM                              | 4 (3.8%)    | 0 (0.0%)      | 0 (0.0%)      | 1.000     | Fisher         |
+|                                                         | Mixed                           | 3 (2.9%)    | 2 (6.1%)      | 1 (1.8%)      | 0.552     | Fisher         |
+| Autoimmune disease, n (%)                               |                                 |             |               |               |           |                |
+|                                                         | MCTD                            | 1 (1.0%)    | 0 (0.0%)      | 1 (1.8%)      | 1.000     | Fisher         |
+|                                                         | RA                              | 1 (1.0%)    | 1 (3.0%)      | 0 (0.0%)      | 0.367     | Fisher         |
+|                                                         | CREST                           | 1 (1.0%)    | 0 (0.0%)      | 0 (0.0%)      | 1.000     | Fisher         |
+|                                                         | MS                              | 2 (1.9%)    | 0 (0.0%)      | 1 (1.8%)      | 1.000     | Fisher         |
+|                                                         | SSc                             | 1 (1.0%)    | 1 (3.0%)      | 0 (0.0%)      | 0.367     | Fisher         |
+|                                                         | Colitis ulcerosa                | 0 (0.0%)    | 0 (0.0%)      | 0 (0.0%)      | 1.000     | Fisher         |
+|                                                         | Glomerulonephritis              | 0 (0.0%)    | 0 (0.0%)      | 0 (0.0%)      | 1.000     | Fisher         |
+|                                                         | NMDA-encephalitis               | 1 (1.0%)    | 0 (0.0%)      | 1 (1.8%)      | 1.000     | Fisher         |
+| Transplantation, n (%)                                  |                                 |             |               |               |           |                |
+|                                                         | LT                              | 2 (1.9%)    | 2 (6.1%)      | 0 (0.0%)      | 0.132     | Fisher         |
+|                                                         | KT                              | 2 (1.9%)    | 1 (3.0%)      | 1 (1.8%)      | 1.000     | Fisher         |
+| Disease group, n (%)                                    |                                 |             |               |               |           |                |
+|                                                         | Haematological malignancy       | 93 (89.4%)  | 28 (84.8%)    | 53 (93.0%)    | 0.279     | Fisher         |
+|                                                         | Autoimmune disease              | 7 (6.7%)    | 2 (6.1%)      | 3 (5.3%)      | 1.000     | Fisher         |
+|                                                         | Transplantation                 | 4 (3.8%)    | 3 (9.1%)      | 1 (1.8%)      | 0.138     | Fisher         |
+| Immunosuppressive treatment, n (%)                      |                                 |             |               |               |           |                |
+|                                                         | None                            | 24 (23.1%)  | 10 (30.3%)    | 8 (14.0%)     | 0.113     | Chi2 df=1      |
+|                                                         | Anti-CD-20                      | 77 (74.0%)  | 23 (69.7%)    | 46 (80.7%)    | 0.352     | Chi2 df=1      |
+|                                                         | CAR-T                           | 3 (2.9%)    | 0 (0.0%)      | 3 (5.3%)      | 0.296     | Fisher         |
+| Glucocorticoid use, n (%)                               |                                 | 47 (45.2%)  | 13 (39.4%)    | 29 (50.9%)    | 0.405     | Chi2 df=1      |
+| SARS-CoV-2 vaccination, n (%)                           |                                 | 95 (91.3%)  | 30 (90.9%)    | 53 (93.0%)    | 0.704     | Fisher         |
+| Number of vaccine doses, n (range)                      |                                 | 2-8         | 2-6           | 2-8           | 0.651     | Mann-Whitney-U |
+| Thoracic CT changes, n (%)                              |                                 | 62 (59.6%)  | 17 (51.5%)    | 38 (66.7%)    | 0.231     | Chi2 df=1      |
+| Duration of SARS-CoV-2 replication (days), median (IQR) |                                 | 64 (33-120) | 79 (33-135)   | 71 (38-116)   | 0.766     | Mann-Whitney-U |
+| SARS-CoV-2 genotype, n (%)                              |                                 |             |               |               |           |                |
+|                                                         | BA.5-derived Omicron subvariant | 31 (29.8%)  | 6 (18.2%)     | 21 (36.8%)    | 0.105     | Chi2 df=1      |
+|                                                         | BA.2-derived Omicron subvariant | 8 (7.7%)    | 4 (12.1%)     | 4 (7.0%)      | 0.458     | Fisher         |
+|                                                         | BA.1-derived Omicron subvariant | 9 (8.7%)    | 5 (15.2%)     | 4 (7.0%)      | 0.279     | Fisher         |
+|                                                         | Other                           | 56 (53.8%)  | 18 (54.5%)    | 28 (49.1%)    | 0.782     | Chi2 df=1      |
+| Prolonged viral shedding (≥ 14 days), n (%)             |                                 | 90 (86.5%)  | 33 (100.0%)   | 57 (100.0%)   | 1.000     | Fisher         |
+| Survival, n (%)                                         |                                 | 94 (90.4%)  | 31 (93.9%)    | 53 (93.0%)    | 1.000     | Fisher         |
+| Adverse events, n (%)                                   |                                 |             |               |               |           |                |
+|                                                         | None                            | 98 (94.2%)  | 32 (97.0%)    | 52 (91.2%)    | 0.409     | Fisher         |
+|                                                         | Thrombocytopenia                | 1 (1.0%)    | 0 (0.0%)      | 1 (1.8%)      | 1.000     | Fisher         |
+|                                                         | Other                           | 5 (4.8%)    | 1 (3.0%)      | 4 (7.0%)      | 0.648     | Fisher         |
 
 
 
-# Table B
+# Table B. Outcomes in all cohorts
 
 | row                                  | subrow   | Total      | Monotherapy   | Combination   |   p-value | test   |
 |:-------------------------------------|:---------|:-----------|:--------------|:--------------|----------:|:-------|


### PR DESCRIPTION
## Summary
- show correct table titles in `tables.md`
- display one p-value when subrows share a single test
- rename MWU test label to `Mann-Whitney-U`

## Testing
- `pytest -q`
- `flake8`
- `python run_tables.py`

------
https://chatgpt.com/codex/tasks/task_e_68823c63ec7883338864fb61e9b0ea9a