### PR TITLE
Fix footnote formatting

### DIFF
--- a/run_tables.py
+++ b/run_tables.py
@@ -334,9 +334,8 @@ def section(title, tab, tests, subrows=True):
         df.insert(0, "row", df.index)
         df["test"] = [tests.get(idx, "") for idx in df.index]
     body = df.reset_index(drop=True).to_markdown(index=False)
-    foot = tab.attrs.get("footnote", "").strip()
-    foot = re.sub(r"\s*(?=Abbreviations:)", "\n", foot)
-    foot = re.sub(r"\s*(?=\d+:)", "\n", foot)
+    foot = tab.attrs.get("footnote", "")
+    foot = re.sub(r"\s*(?=Abbreviations:|\d+:)", "\n", foot).strip()
     foot = "\n".join(s.strip() for s in foot.splitlines() if s.strip())
     text = "# " + title + "\n\n" + body + "\n\n" + foot + "\n\n"
     return text


### PR DESCRIPTION
## Summary
- improve footnote formatting to always start on a new line

## Testing
- `flake8`
- `pytest -q`
- `python run_tables.py`

------
https://chatgpt.com/codex/tasks/task_e_688245b2cd788333947f20fb3f5bb436