### PR TITLE
Add test for run_tables output

### DIFF
--- a/tests/test_run_tables.py
+++ b/tests/test_run_tables.py
@@ -1,0 +1,19 @@
+import importlib.util
+import pathlib
+import sys
+
+path = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(path))
+spec = importlib.util.spec_from_file_location('run_tables', path / 'run_tables.py')
+run_tables = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(run_tables)
+
+
+def test_run_tables_output():
+    for f in ['code.md', 'tables.md']:
+        p = path / f
+        if p.exists():
+            p.unlink()
+    run_tables.main()
+    assert (path / 'code.md').exists()
+    assert (path / 'tables.md').exists()


### PR DESCRIPTION
## Summary
- add `tests/test_run_tables.py` to ensure `run_tables.main()` produces `code.md` and `tables.md`
- run tables script to refresh markdown outputs

## Testing
- `pytest -q`
- `flake8`
- `python run_tables.py`

------
https://chatgpt.com/codex/tasks/task_e_6883209b3a948333a91c4cdac42ed91f