### PR TITLE
Add NOS row to hematological malignancy details

### DIFF
--- a/code.md
+++ b/code.md
@@ -167,6 +167,8 @@ def heme_subtype(x):
         return 'MM'
     if ',' in s or '+' in s:
         return 'Mixed'
+    if s.strip() == 'nos':
+        return 'NOS'
     if s.strip():
         return 'Other'
     return None
@@ -807,7 +809,8 @@ __all__ = [
 index = pd.MultiIndex.from_tuples(
     [
         ('Haematological malignancy, n (%)', ''),
-        ('Haematological malignancy, n (%)', 'Other'),
+        ('Haematological malignancy, n (%)', 'Other\u00b9'),
+        ('Haematological malignancy, n (%)', 'NOS'),
         ('Haematological malignancy, n (%)', 'DLBCL'),
         ('Haematological malignancy, n (%)', 'ALL'),
         ('Haematological malignancy, n (%)', 'CLL'),
@@ -873,13 +876,14 @@ def build_table_c():
     table_c.loc[('Transplantation, n (%)', '')] = ''
     table_c.loc[('SARS-CoV-2 genotype, n (%)', '')] = ''
     table_c.loc[('Adverse events, n (%)', '')] = ''
-    labs = ['Other', 'DLBCL', 'ALL', 'CLL', 'AML', 'FL', 'NHL', 'MM', 'Mixed']
+    labs = ['Other\u00b9', 'NOS', 'DLBCL', 'ALL', 'CLL', 'AML', 'FL', 'NHL', 'MM', 'Mixed']
     for lab in labs:
+        db_lab = 'Other' if lab == 'Other\u00b9' else lab
         add_rate(
             ('Haematological malignancy, n (%)', lab),
-            TOTAL['heme'] == lab,
-            MONO['heme'] == lab,
-            COMBO['heme'] == lab,
+            TOTAL['heme'] == db_lab,
+            MONO['heme'] == db_lab,
+            COMBO['heme'] == db_lab,
         )
     labs = [
         'MCTD',
@@ -938,6 +942,10 @@ def build_table_c():
     )
     for lab in ['None', 'Thrombocytopenia', 'Other']:
         add_rate(('Adverse events, n (%)', lab), TOTAL['adv'] == lab, MONO['adv'] == lab, COMBO['adv'] == lab)
+    table_c.attrs['footnote'] = (
+        '1: Other includes MCD, MCTD, CREST, ANCA-Vasculitis, KT, LT, MS, '
+        'NMDA-encephalitis, RA.'
+    )
     return table_c
 
 

--- a/data_preprocessing.py
+++ b/data_preprocessing.py
@@ -167,6 +167,8 @@ def heme_subtype(x):
         return 'MM'
     if ',' in s or '+' in s:
         return 'Mixed'
+    if s.strip() == 'nos':
+        return 'NOS'
     if s.strip():
         return 'Other'
     return None

--- a/table_c.py
+++ b/table_c.py
@@ -11,7 +11,8 @@ from data_preprocessing import (
 index = pd.MultiIndex.from_tuples(
     [
         ('Haematological malignancy, n (%)', ''),
-        ('Haematological malignancy, n (%)', 'Other'),
+        ('Haematological malignancy, n (%)', 'Other\u00b9'),
+        ('Haematological malignancy, n (%)', 'NOS'),
         ('Haematological malignancy, n (%)', 'DLBCL'),
         ('Haematological malignancy, n (%)', 'ALL'),
         ('Haematological malignancy, n (%)', 'CLL'),
@@ -77,13 +78,14 @@ def build_table_c():
     table_c.loc[('Transplantation, n (%)', '')] = ''
     table_c.loc[('SARS-CoV-2 genotype, n (%)', '')] = ''
     table_c.loc[('Adverse events, n (%)', '')] = ''
-    labs = ['Other', 'DLBCL', 'ALL', 'CLL', 'AML', 'FL', 'NHL', 'MM', 'Mixed']
+    labs = ['Other\u00b9', 'NOS', 'DLBCL', 'ALL', 'CLL', 'AML', 'FL', 'NHL', 'MM', 'Mixed']
     for lab in labs:
+        db_lab = 'Other' if lab == 'Other\u00b9' else lab
         add_rate(
             ('Haematological malignancy, n (%)', lab),
-            TOTAL['heme'] == lab,
-            MONO['heme'] == lab,
-            COMBO['heme'] == lab,
+            TOTAL['heme'] == db_lab,
+            MONO['heme'] == db_lab,
+            COMBO['heme'] == db_lab,
         )
     labs = [
         'MCTD',
@@ -142,6 +144,10 @@ def build_table_c():
     )
     for lab in ['None', 'Thrombocytopenia', 'Other']:
         add_rate(('Adverse events, n (%)', lab), TOTAL['adv'] == lab, MONO['adv'] == lab, COMBO['adv'] == lab)
+    table_c.attrs['footnote'] = (
+        '1: Other includes MCD, MCTD, CREST, ANCA-Vasculitis, KT, LT, MS, '
+        'NMDA-encephalitis, RA.'
+    )
     return table_c
 
 

--- a/tables.md
+++ b/tables.md
@@ -55,7 +55,8 @@
 | row                                                     | subrow             | Total       | Monotherapy   | Combination   | p-value   | test           |
 |:--------------------------------------------------------|:-------------------|:------------|:--------------|:--------------|:----------|:---------------|
 | Haematological malignancy, n (%)                        |                    |             |               |               |           |                |
-|                                                         | Other              | 20 (19.2%)  | 8 (24.2%)     | 10 (17.5%)    | 0.623     | Chi2 df=1      |
+|                                                         | Other¹             | 9 (8.7%)    | 4 (12.1%)     | 3 (5.3%)      | 0.255     |                |
+|                                                         | NOS                | 11 (10.6%)  | 4 (12.1%)     | 7 (12.3%)     | 1.000     |                |
 |                                                         | DLBCL              | 14 (13.5%)  | 1 (3.0%)      | 11 (19.3%)    | 0.050     | Fisher         |
 |                                                         | ALL                | 6 (5.8%)    | 5 (15.2%)     | 1 (1.8%)      | 0.024     | Fisher         |
 |                                                         | CLL                | 6 (5.8%)    | 0 (0.0%)      | 5 (8.8%)      | 0.154     | Fisher         |
@@ -89,7 +90,7 @@
 |                                                         | Thrombocytopenia   | 1 (1.0%)    | 0 (0.0%)      | 1 (1.8%)      | 1.000     | Fisher         |
 |                                                         | Other              | 5 (4.8%)    | 1 (3.0%)      | 4 (7.0%)      | 0.648     | Fisher         |
 
-
+1: Other includes MCD, MCTD, CREST, ANCA-Vasculitis, KT, LT, MS, NMDA-encephalitis, RA.
 
 # Table D. Outcomes in all cohorts
 

--- a/tables_no_test.md
+++ b/tables_no_test.md
@@ -57,7 +57,8 @@
 | row                                                     | subrow             | Total       | Monotherapy   | Combination   | p-value   |
 |:--------------------------------------------------------|:-------------------|:------------|:--------------|:--------------|:----------|
 | Haematological malignancy, n (%)                        |                    |             |               |               |           |
-|                                                         | Other              | 20 (19.2%)  | 8 (24.2%)     | 10 (17.5%)    | 0.623     |
+|                                                         | Other¹             | 9 (8.7%)    | 4 (12.1%)     | 3 (5.3%)      | 0.255     |
+|                                                         | NOS                | 11 (10.6%)  | 4 (12.1%)     | 7 (12.3%)     | 1.000     |
 |                                                         | DLBCL              | 14 (13.5%)  | 1 (3.0%)      | 11 (19.3%)    | 0.050     |
 |                                                         | ALL                | 6 (5.8%)    | 5 (15.2%)     | 1 (1.8%)      | 0.024     |
 |                                                         | CLL                | 6 (5.8%)    | 0 (0.0%)      | 5 (8.8%)      | 0.154     |
@@ -91,7 +92,7 @@
 |                                                         | Thrombocytopenia   | 1 (1.0%)    | 0 (0.0%)      | 1 (1.8%)      | 1.000     |
 |                                                         | Other              | 5 (4.8%)    | 1 (3.0%)      | 4 (7.0%)      | 0.648     |
 
-
+1: Other includes MCD, MCTD, CREST, ANCA-Vasculitis, KT, LT, MS, NMDA-encephalitis, RA.  
 
    
 # Table D. Outcomes in all cohorts
@@ -107,3 +108,4 @@
 2: defined as subjects with parameter “survival outcome: no”    
 3: defined as subjects with parameters “eradication outcome successful: no” AND “survival outcome: no”    
 4: defined as subjects with parameter “adverse events: yes”  
+


### PR DESCRIPTION
## Summary
- classify baseline NOS separately in `heme_subtype`
- split "Other" in Table C into "NOS" and the remaining diagnoses
- document which diagnoses are aggregated under Other
- regenerate tables

## Testing
- `flake8`
- `pytest -q`
- `python run_tables.py`

------
https://chatgpt.com/codex/tasks/task_e_68876166782c8333a459e8b4fe8deb9b