### PR TITLE
Update immunosuppression mapping

### DIFF
--- a/code.md
+++ b/code.md
@@ -129,7 +129,10 @@ def parse_vacc(x: str):
 
 
 def group_immuno(x: str) -> str:
-    tags = re.split(r'[,\s]+', str(x).lower().strip())
+    s = str(x).lower().strip()
+    if s in {'nan', 'na', 'n/a', 'none', ''}:
+        return 'None'
+    tags = re.split(r'[,\s]+', s)
     labs = set()
     for t in tags:
         if not t:
@@ -140,12 +143,8 @@ def group_immuno(x: str) -> str:
             labs.add('HSCT')
         elif 'car' in t and 'cd20' not in t and 'hsct' not in t:
             labs.add('CAR-T')
-        elif t in {'na', 'n/a', 'nan', ''}:
-            pass
         else:
             labs.add('Other')
-    if not labs:
-        return 'None'
     return labs.pop() if len(labs) == 1 else 'Other'
 
 
@@ -219,7 +218,7 @@ def disease_group(x):
 
 def immuno_cat(x):
     s = str(x).lower().strip()
-    if not s or s in {'nan', 'na', 'n/a'}:
+    if s in {'nan', 'na', 'n/a', 'none', ''}:
         return 'None'
     if 'cd20' in s and 'hsct' not in s and 'car' not in s:
         return 'Anti-CD-20'
@@ -352,7 +351,7 @@ def add_flags_extended(df: pd.DataFrame) -> pd.DataFrame:
     df['flag_cd20'] = base.str.contains('cd20') & ~base.str.contains('hsct') & ~base.str.contains('car')
     df['flag_cart'] = base.str.contains('car') & ~base.str.contains('cd20') & ~base.str.contains('hsct')
     df['flag_hsct'] = base.str.contains('hsct') & ~base.str.contains('cd20') & ~base.str.contains('car')
-    df['flag_immuno_none'] = base.isin({'', 'nan', 'na', 'n/a'})
+    df['flag_immuno_none'] = base.isin({'', 'nan', 'na', 'n/a', 'none'})
     df['flag_immuno_other'] = ~(
         df[['flag_cd20', 'flag_cart', 'flag_hsct', 'flag_immuno_none']].any(axis=1)
     )

--- a/code.md
+++ b/code.md
@@ -129,24 +129,24 @@ def parse_vacc(x: str):
 
 
 def group_immuno(x: str) -> str:
-    tags = re.split(r'[,\s]+', str(x).lower())
+    tags = re.split(r'[,\s]+', str(x).lower().strip())
     labs = set()
     for t in tags:
         if not t:
             continue
-        if 'cd20' in t:
+        if 'cd20' in t and 'hsct' not in t and 'car' not in t:
             labs.add('CD20')
-        elif 'car' in t:
-            labs.add('CAR-T')
-        elif 'hsct' in t:
+        elif 'hsct' in t and 'cd20' not in t and 'car' not in t:
             labs.add('HSCT')
-        elif 'none' in t:
-            labs.add('none')
+        elif 'car' in t and 'cd20' not in t and 'hsct' not in t:
+            labs.add('CAR-T')
+        elif t in {'na', 'n/a', 'nan', ''}:
+            pass
         else:
             labs.add('Other')
     if not labs:
-        return 'none'
-    return labs.pop() if len(labs) == 1 else 'Mixed'
+        return 'None'
+    return labs.pop() if len(labs) == 1 else 'Other'
 
 
 def heme_subtype(x):
@@ -218,12 +218,16 @@ def disease_group(x):
 
 
 def immuno_cat(x):
-    s = str(x).lower()
-    if 'cd20' in s:
+    s = str(x).lower().strip()
+    if not s or s in {'nan', 'na', 'n/a'}:
+        return 'None'
+    if 'cd20' in s and 'hsct' not in s and 'car' not in s:
         return 'Anti-CD-20'
-    if 'car' in s:
+    if 'hsct' in s and 'cd20' not in s and 'car' not in s:
+        return 'HSCT'
+    if 'car' in s and 'cd20' not in s and 'hsct' not in s:
         return 'CAR-T'
-    return 'None'
+    return 'Other'
 
 
 def geno_cat(x):
@@ -344,13 +348,14 @@ def add_flags_extended(df: pd.DataFrame) -> pd.DataFrame:
     df['flag_malign'] = s.map(lambda x: parse_has(x, 'm'))
     df['flag_autoimm'] = s.map(lambda x: parse_has(x, 'a'))
     df['flag_transpl'] = s.map(lambda x: parse_has(x, 't'))
-    base = df[COL_BASE].astype(str).str.lower()
-    df['flag_cd20'] = base.str.contains('cd20')
-    df['flag_cart'] = base.str.contains('car')
-    df['flag_hsct'] = base.str.contains('hsct')
-    df['flag_immuno_none'] = ~(
-        df[['flag_cd20', 'flag_cart', 'flag_hsct']].any(axis=1)
-    ) | base.str.contains('none')
+    base = df[COL_BASE].astype(str).str.lower().str.strip()
+    df['flag_cd20'] = base.str.contains('cd20') & ~base.str.contains('hsct') & ~base.str.contains('car')
+    df['flag_cart'] = base.str.contains('car') & ~base.str.contains('cd20') & ~base.str.contains('hsct')
+    df['flag_hsct'] = base.str.contains('hsct') & ~base.str.contains('cd20') & ~base.str.contains('car')
+    df['flag_immuno_none'] = base.isin({'', 'nan', 'na', 'n/a'})
+    df['flag_immuno_other'] = ~(
+        df[['flag_cd20', 'flag_cart', 'flag_hsct', 'flag_immuno_none']].any(axis=1)
+    )
     df['flag_gc'] = df[COL_GC].map(parse_yn)
     vacc = df[COL_VACC].map(parse_vacc)
     df['vacc_yes'] = vacc.map(lambda x: x[0] == 'Yes')
@@ -371,7 +376,7 @@ add_flags_extended(COMBO)
 
 
 def baseline_stats() -> pd.DataFrame:
-    labels = ['CD20', 'CAR-T', 'HSCT', 'Other', 'none', 'Mixed']
+    labels = ['CD20', 'CAR-T', 'HSCT', 'Other', 'None']
     t = TOTAL[COL_BASE].map(group_immuno)
     m = MONO[COL_BASE].map(group_immuno)
     c = COMBO[COL_BASE].map(group_immuno)
@@ -656,6 +661,7 @@ index = pd.MultiIndex.from_tuples(
         ('Immunosuppressive treatment, n (%)', 'Anti-CD20'),
         ('Immunosuppressive treatment, n (%)', 'CAR-T'),
         ('Immunosuppressive treatment, n (%)', 'HSCT'),
+        ('Immunosuppressive treatment, n (%)', 'Other'),
         ('Immunosuppressive treatment, n (%)', 'None'),
         ('Glucocorticoid use, n (%)', ''),
         ('SARS-CoV-2 vaccination, n (%)', ''),
@@ -727,6 +733,7 @@ def build_table_b():
         ('Anti-CD20', 'flag_cd20'),
         ('CAR-T', 'flag_cart'),
         ('HSCT', 'flag_hsct'),
+        ('Other', 'flag_immuno_other'),
         ('None', 'flag_immuno_none'),
     ]
     for lbl, col in pairs:
@@ -768,9 +775,16 @@ def build_table_b():
     table_b.at[('Treatment setting\u00b9, n (%)', 'Hospital'), 'p-value'] = ''
     table_b.at[('Treatment setting\u00b9, n (%)', 'Outpatient'), 'p-value'] = ''
     table_b.at[('Treatment setting\u00b9, n (%)', ''), 'p-value'] = fmt_p(p_set)
+    vals = (
+        TOTAL.loc[TOTAL['flag_immuno_other'], COL_BASE]
+        .dropna()
+        .unique()
+    )
+    extra = '; '.join(str(v) for v in vals)
     foot = (
         '- NMV-r, nirmatrelvir-ritonavir.\n'
-        '1: Treatment setting where prolonged NMV-r was administered.'
+        '1: Treatment setting where prolonged NMV-r was administered.\n'
+        f'2: Other immunosuppressive treatment: {extra}.'
     )
     table_b.attrs['footnote'] = foot
     table_b_raw.attrs['footnote'] = foot

--- a/data_preprocessing.py
+++ b/data_preprocessing.py
@@ -129,7 +129,10 @@ def parse_vacc(x: str):
 
 
 def group_immuno(x: str) -> str:
-    tags = re.split(r'[,\s]+', str(x).lower().strip())
+    s = str(x).lower().strip()
+    if s in {'nan', 'na', 'n/a', 'none', ''}:
+        return 'None'
+    tags = re.split(r'[,\s]+', s)
     labs = set()
     for t in tags:
         if not t:
@@ -140,12 +143,8 @@ def group_immuno(x: str) -> str:
             labs.add('HSCT')
         elif 'car' in t and 'cd20' not in t and 'hsct' not in t:
             labs.add('CAR-T')
-        elif t in {'na', 'n/a', 'nan', ''}:
-            pass
         else:
             labs.add('Other')
-    if not labs:
-        return 'None'
     return labs.pop() if len(labs) == 1 else 'Other'
 
 
@@ -219,7 +218,7 @@ def disease_group(x):
 
 def immuno_cat(x):
     s = str(x).lower().strip()
-    if not s or s in {'nan', 'na', 'n/a'}:
+    if s in {'nan', 'na', 'n/a', 'none', ''}:
         return 'None'
     if 'cd20' in s and 'hsct' not in s and 'car' not in s:
         return 'Anti-CD-20'
@@ -352,7 +351,7 @@ def add_flags_extended(df: pd.DataFrame) -> pd.DataFrame:
     df['flag_cd20'] = base.str.contains('cd20') & ~base.str.contains('hsct') & ~base.str.contains('car')
     df['flag_cart'] = base.str.contains('car') & ~base.str.contains('cd20') & ~base.str.contains('hsct')
     df['flag_hsct'] = base.str.contains('hsct') & ~base.str.contains('cd20') & ~base.str.contains('car')
-    df['flag_immuno_none'] = base.isin({'', 'nan', 'na', 'n/a'})
+    df['flag_immuno_none'] = base.isin({'', 'nan', 'na', 'n/a', 'none'})
     df['flag_immuno_other'] = ~(
         df[['flag_cd20', 'flag_cart', 'flag_hsct', 'flag_immuno_none']].any(axis=1)
     )

--- a/data_preprocessing.py
+++ b/data_preprocessing.py
@@ -129,24 +129,24 @@ def parse_vacc(x: str):
 
 
 def group_immuno(x: str) -> str:
-    tags = re.split(r'[,\s]+', str(x).lower())
+    tags = re.split(r'[,\s]+', str(x).lower().strip())
     labs = set()
     for t in tags:
         if not t:
             continue
-        if 'cd20' in t:
+        if 'cd20' in t and 'hsct' not in t and 'car' not in t:
             labs.add('CD20')
-        elif 'car' in t:
-            labs.add('CAR-T')
-        elif 'hsct' in t:
+        elif 'hsct' in t and 'cd20' not in t and 'car' not in t:
             labs.add('HSCT')
-        elif 'none' in t:
-            labs.add('none')
+        elif 'car' in t and 'cd20' not in t and 'hsct' not in t:
+            labs.add('CAR-T')
+        elif t in {'na', 'n/a', 'nan', ''}:
+            pass
         else:
             labs.add('Other')
     if not labs:
-        return 'none'
-    return labs.pop() if len(labs) == 1 else 'Mixed'
+        return 'None'
+    return labs.pop() if len(labs) == 1 else 'Other'
 
 
 def heme_subtype(x):
@@ -218,12 +218,16 @@ def disease_group(x):
 
 
 def immuno_cat(x):
-    s = str(x).lower()
-    if 'cd20' in s:
+    s = str(x).lower().strip()
+    if not s or s in {'nan', 'na', 'n/a'}:
+        return 'None'
+    if 'cd20' in s and 'hsct' not in s and 'car' not in s:
         return 'Anti-CD-20'
-    if 'car' in s:
+    if 'hsct' in s and 'cd20' not in s and 'car' not in s:
+        return 'HSCT'
+    if 'car' in s and 'cd20' not in s and 'hsct' not in s:
         return 'CAR-T'
-    return 'None'
+    return 'Other'
 
 
 def geno_cat(x):
@@ -344,13 +348,14 @@ def add_flags_extended(df: pd.DataFrame) -> pd.DataFrame:
     df['flag_malign'] = s.map(lambda x: parse_has(x, 'm'))
     df['flag_autoimm'] = s.map(lambda x: parse_has(x, 'a'))
     df['flag_transpl'] = s.map(lambda x: parse_has(x, 't'))
-    base = df[COL_BASE].astype(str).str.lower()
-    df['flag_cd20'] = base.str.contains('cd20')
-    df['flag_cart'] = base.str.contains('car')
-    df['flag_hsct'] = base.str.contains('hsct')
-    df['flag_immuno_none'] = ~(
-        df[['flag_cd20', 'flag_cart', 'flag_hsct']].any(axis=1)
-    ) | base.str.contains('none')
+    base = df[COL_BASE].astype(str).str.lower().str.strip()
+    df['flag_cd20'] = base.str.contains('cd20') & ~base.str.contains('hsct') & ~base.str.contains('car')
+    df['flag_cart'] = base.str.contains('car') & ~base.str.contains('cd20') & ~base.str.contains('hsct')
+    df['flag_hsct'] = base.str.contains('hsct') & ~base.str.contains('cd20') & ~base.str.contains('car')
+    df['flag_immuno_none'] = base.isin({'', 'nan', 'na', 'n/a'})
+    df['flag_immuno_other'] = ~(
+        df[['flag_cd20', 'flag_cart', 'flag_hsct', 'flag_immuno_none']].any(axis=1)
+    )
     df['flag_gc'] = df[COL_GC].map(parse_yn)
     vacc = df[COL_VACC].map(parse_vacc)
     df['vacc_yes'] = vacc.map(lambda x: x[0] == 'Yes')
@@ -371,7 +376,7 @@ add_flags_extended(COMBO)
 
 
 def baseline_stats() -> pd.DataFrame:
-    labels = ['CD20', 'CAR-T', 'HSCT', 'Other', 'none', 'Mixed']
+    labels = ['CD20', 'CAR-T', 'HSCT', 'Other', 'None']
     t = TOTAL[COL_BASE].map(group_immuno)
     m = MONO[COL_BASE].map(group_immuno)
     c = COMBO[COL_BASE].map(group_immuno)

--- a/table_b.py
+++ b/table_b.py
@@ -3,6 +3,7 @@ from data_preprocessing import (
     TOTAL,
     MONO,
     COMBO,
+    COL_BASE,
     fill_rate,
     fill_median_iqr,
     fill_mean_range,
@@ -22,6 +23,7 @@ index = pd.MultiIndex.from_tuples(
         ('Immunosuppressive treatment, n (%)', 'Anti-CD20'),
         ('Immunosuppressive treatment, n (%)', 'CAR-T'),
         ('Immunosuppressive treatment, n (%)', 'HSCT'),
+        ('Immunosuppressive treatment, n (%)', 'Other'),
         ('Immunosuppressive treatment, n (%)', 'None'),
         ('Glucocorticoid use, n (%)', ''),
         ('SARS-CoV-2 vaccination, n (%)', ''),
@@ -93,6 +95,7 @@ def build_table_b():
         ('Anti-CD20', 'flag_cd20'),
         ('CAR-T', 'flag_cart'),
         ('HSCT', 'flag_hsct'),
+        ('Other', 'flag_immuno_other'),
         ('None', 'flag_immuno_none'),
     ]
     for lbl, col in pairs:
@@ -134,9 +137,16 @@ def build_table_b():
     table_b.at[('Treatment setting\u00b9, n (%)', 'Hospital'), 'p-value'] = ''
     table_b.at[('Treatment setting\u00b9, n (%)', 'Outpatient'), 'p-value'] = ''
     table_b.at[('Treatment setting\u00b9, n (%)', ''), 'p-value'] = fmt_p(p_set)
+    vals = (
+        TOTAL.loc[TOTAL['flag_immuno_other'], COL_BASE]
+        .dropna()
+        .unique()
+    )
+    extra = '; '.join(str(v) for v in vals)
     foot = (
         '- NMV-r, nirmatrelvir-ritonavir.\n'
-        '1: Treatment setting where prolonged NMV-r was administered.'
+        '1: Treatment setting where prolonged NMV-r was administered.\n'
+        f'2: Other immunosuppressive treatment: {extra}.'
     )
     table_b.attrs['footnote'] = foot
     table_b_raw.attrs['footnote'] = foot

--- a/tables.md
+++ b/tables.md
@@ -35,10 +35,11 @@
 |                                    | Autoimmune               | 11 (10.6%) | 4 (12.1%)     | 4 (7.0%)      | 0.458     | Fisher         |
 |                                    | Transplantation          | 4 (3.8%)   | 3 (9.1%)      | 1 (1.8%)      | 0.138     | Fisher         |
 | Immunosuppressive treatment, n (%) |                          |            |               |               |           |                |
-|                                    | Anti-CD20                | 79 (76.0%) | 24 (72.7%)    | 47 (82.5%)    | 0.411     | Chi2 df=1      |
-|                                    | None                     | 19 (18.3%) | 7 (21.2%)     | 6 (10.5%)     | 0.216     | Fisher         |
-|                                    | HSCT                     | 4 (3.8%)   | 3 (9.1%)      | 1 (1.8%)      | 0.138     | Fisher         |
-|                                    | CAR-T                    | 4 (3.8%)   | 0 (0.0%)      | 4 (7.0%)      | 0.292     | Fisher         |
+|                                    | Anti-CD20                | 77 (74.0%) | 23 (69.7%)    | 46 (80.7%)    | 0.352     | Chi2 df=1      |
+|                                    | Other                    | 21 (20.2%) | 8 (24.2%)     | 7 (12.3%)     | 0.240     | Fisher         |
+|                                    | HSCT                     | 3 (2.9%)   | 2 (6.1%)      | 1 (1.8%)      | 0.552     | Fisher         |
+|                                    | CAR-T                    | 3 (2.9%)   | 0 (0.0%)      | 3 (5.3%)      | 0.296     |                |
+|                                    | None                     | 0 (0.0%)   | 0 (0.0%)      | 0 (0.0%)      | 1.000     | Fisher         |
 | Glucocorticoid use, n (%)          |                          | 47 (45.2%) | 13 (39.4%)    | 29 (50.9%)    | 0.405     | Chi2 df=1      |
 | SARS-CoV-2 vaccination, n (%)      |                          | 95 (91.3%) | 30 (90.9%)    | 53 (93.0%)    | 0.704     | Fisher         |
 | Mean Vaccination doses, n (range)  |                          | 3.3 (2-8)  | 3.3 (2-6)     | 3.3 (2-8)     | 0.651     | Mann-Whitney-U |
@@ -49,6 +50,7 @@
 
 - NMV-r, nirmatrelvir-ritonavir.
 1: Treatment setting where prolonged NMV-r was administered.
+2: Other immunosuppressive treatment: none; Other; HSCT, CD20; CD20, CAR-T.
 
 # Table C. Detailed Patient Characteristics
 

--- a/tables.md
+++ b/tables.md
@@ -36,10 +36,10 @@
 |                                    | Transplantation          | 4 (3.8%)   | 3 (9.1%)      | 1 (1.8%)      | 0.138     | Fisher         |
 | Immunosuppressive treatment, n (%) |                          |            |               |               |           |                |
 |                                    | Anti-CD20                | 77 (74.0%) | 23 (69.7%)    | 46 (80.7%)    | 0.352     | Chi2 df=1      |
-|                                    | Other                    | 21 (20.2%) | 8 (24.2%)     | 7 (12.3%)     | 0.240     | Fisher         |
-|                                    | HSCT                     | 3 (2.9%)   | 2 (6.1%)      | 1 (1.8%)      | 0.552     | Fisher         |
-|                                    | CAR-T                    | 3 (2.9%)   | 0 (0.0%)      | 3 (5.3%)      | 0.296     |                |
-|                                    | None                     | 0 (0.0%)   | 0 (0.0%)      | 0 (0.0%)      | 1.000     | Fisher         |
+|                                    | Other                    | 15 (14.4%) | 6 (18.2%)     | 5 (8.8%)      | 0.202     | Fisher         |
+|                                    | None                     | 6 (5.8%)   | 2 (6.1%)      | 2 (3.5%)      | 0.622     | Fisher         |
+|                                    | HSCT                     | 3 (2.9%)   | 2 (6.1%)      | 1 (1.8%)      | 0.552     |                |
+|                                    | CAR-T                    | 3 (2.9%)   | 0 (0.0%)      | 3 (5.3%)      | 0.296     | Fisher         |
 | Glucocorticoid use, n (%)          |                          | 47 (45.2%) | 13 (39.4%)    | 29 (50.9%)    | 0.405     | Chi2 df=1      |
 | SARS-CoV-2 vaccination, n (%)      |                          | 95 (91.3%) | 30 (90.9%)    | 53 (93.0%)    | 0.704     | Fisher         |
 | Mean Vaccination doses, n (range)  |                          | 3.3 (2-8)  | 3.3 (2-6)     | 3.3 (2-8)     | 0.651     | Mann-Whitney-U |
@@ -50,7 +50,7 @@
 
 - NMV-r, nirmatrelvir-ritonavir.
 1: Treatment setting where prolonged NMV-r was administered.
-2: Other immunosuppressive treatment: none; Other; HSCT, CD20; CD20, CAR-T.
+2: Other immunosuppressive treatment: Other; HSCT, CD20; CD20, CAR-T.
 
 # Table C. Detailed Patient Characteristics
 

--- a/tables_no_test.md
+++ b/tables_no_test.md
@@ -37,10 +37,10 @@
 |                                    | Transplantation          | 4 (3.8%)   | 3 (9.1%)      | 1 (1.8%)      | 0.138     |
 | Immunosuppressive treatment, n (%) |                          |            |               |               |           |
 |                                    | Anti-CD20                | 77 (74.0%) | 23 (69.7%)    | 46 (80.7%)    | 0.352     |
-|                                    | Other                    | 21 (20.2%) | 8 (24.2%)     | 7 (12.3%)     | 0.240     |
+|                                    | Other                    | 15 (14.4%) | 6 (18.2%)     | 5 (8.8%)      | 0.202     |
+|                                    | None                     | 6 (5.8%)   | 2 (6.1%)      | 2 (3.5%)      | 0.622     |
 |                                    | HSCT                     | 3 (2.9%)   | 2 (6.1%)      | 1 (1.8%)      | 0.552     |
 |                                    | CAR-T                    | 3 (2.9%)   | 0 (0.0%)      | 3 (5.3%)      | 0.296     |
-|                                    | None                     | 0 (0.0%)   | 0 (0.0%)      | 0 (0.0%)      | 1.000     |
 | Glucocorticoid use, n (%)          |                          | 47 (45.2%) | 13 (39.4%)    | 29 (50.9%)    | 0.405     |
 | SARS-CoV-2 vaccination, n (%)      |                          | 95 (91.3%) | 30 (90.9%)    | 53 (93.0%)    | 0.704     |
 | Mean Vaccination doses, n (range)  |                          | 3.3 (2-8)  | 3.3 (2-6)     | 3.3 (2-8)     | 0.651     |
@@ -51,7 +51,7 @@
 
 - NMV-r, nirmatrelvir-ritonavir.    
 1: Treatment setting where prolonged NMV-r was administered.    
-2: Other immunosuppressive treatment: none; Other; HSCT, CD20; CD20, CAR-T.  
+2: Other immunosuppressive treatment: Other; HSCT, CD20; CD20, CAR-T.  
 
 \newpage
 # Table C. Detailed Patient Characteristics

--- a/tables_no_test.md
+++ b/tables_no_test.md
@@ -36,10 +36,11 @@
 |                                    | Autoimmune               | 11 (10.6%) | 4 (12.1%)     | 4 (7.0%)      | 0.458     |
 |                                    | Transplantation          | 4 (3.8%)   | 3 (9.1%)      | 1 (1.8%)      | 0.138     |
 | Immunosuppressive treatment, n (%) |                          |            |               |               |           |
-|                                    | Anti-CD20                | 79 (76.0%) | 24 (72.7%)    | 47 (82.5%)    | 0.411     |
-|                                    | None                     | 19 (18.3%) | 7 (21.2%)     | 6 (10.5%)     | 0.216     |
-|                                    | HSCT                     | 4 (3.8%)   | 3 (9.1%)      | 1 (1.8%)      | 0.138     |
-|                                    | CAR-T                    | 4 (3.8%)   | 0 (0.0%)      | 4 (7.0%)      | 0.292     |
+|                                    | Anti-CD20                | 77 (74.0%) | 23 (69.7%)    | 46 (80.7%)    | 0.352     |
+|                                    | Other                    | 21 (20.2%) | 8 (24.2%)     | 7 (12.3%)     | 0.240     |
+|                                    | HSCT                     | 3 (2.9%)   | 2 (6.1%)      | 1 (1.8%)      | 0.552     |
+|                                    | CAR-T                    | 3 (2.9%)   | 0 (0.0%)      | 3 (5.3%)      | 0.296     |
+|                                    | None                     | 0 (0.0%)   | 0 (0.0%)      | 0 (0.0%)      | 1.000     |
 | Glucocorticoid use, n (%)          |                          | 47 (45.2%) | 13 (39.4%)    | 29 (50.9%)    | 0.405     |
 | SARS-CoV-2 vaccination, n (%)      |                          | 95 (91.3%) | 30 (90.9%)    | 53 (93.0%)    | 0.704     |
 | Mean Vaccination doses, n (range)  |                          | 3.3 (2-8)  | 3.3 (2-6)     | 3.3 (2-8)     | 0.651     |
@@ -49,7 +50,8 @@
 |                                    | Outpatient               | 49 (47.1%) | 16 (48.5%)    | 24 (42.1%)    |           |
 
 - NMV-r, nirmatrelvir-ritonavir.    
-1: Treatment setting where prolonged NMV-r was administered.  
+1: Treatment setting where prolonged NMV-r was administered.    
+2: Other immunosuppressive treatment: none; Other; HSCT, CD20; CD20, CAR-T.  
 
 \newpage
 # Table C. Detailed Patient Characteristics


### PR DESCRIPTION
## Summary
- refine mapping of baseline immunosuppression
- show "Other" as separate row in Table B
- document which therapies were grouped under "Other"

## Testing
- `flake8`
- `pytest -q`
- `python run_tables.py`

------
https://chatgpt.com/codex/tasks/task_e_6888cad2abb883338b1efe77d96f7b2b