### PR TITLE
Add footnote for immunosuppressive 'Other'

### DIFF
--- a/code.md
+++ b/code.md
@@ -664,7 +664,7 @@ index = pd.MultiIndex.from_tuples(
         ('Immunosuppressive treatment, n (%)', 'Anti-CD20'),
         ('Immunosuppressive treatment, n (%)', 'CAR-T'),
         ('Immunosuppressive treatment, n (%)', 'HSCT'),
-        ('Immunosuppressive treatment, n (%)', 'Other'),
+        ('Immunosuppressive treatment, n (%)', 'Other\u00b2'),
         ('Immunosuppressive treatment, n (%)', 'None'),
         ('Glucocorticoid use, n (%)', ''),
         ('SARS-CoV-2 vaccination, n (%)', ''),
@@ -736,7 +736,7 @@ def build_table_b():
         ('Anti-CD20', 'flag_cd20'),
         ('CAR-T', 'flag_cart'),
         ('HSCT', 'flag_hsct'),
-        ('Other', 'flag_immuno_other'),
+        ('Other\u00b2', 'flag_immuno_other'),
         ('None', 'flag_immuno_none'),
     ]
     for lbl, col in pairs:
@@ -787,7 +787,7 @@ def build_table_b():
     foot = (
         '- NMV-r, nirmatrelvir-ritonavir.\n'
         '1: Treatment setting where prolonged NMV-r was administered.\n'
-        f'2: Other immunosuppressive treatment: {extra}.'
+        f'2: Other immunosuppressive treatment includes: {extra}.'
     )
     table_b.attrs['footnote'] = foot
     table_b_raw.attrs['footnote'] = foot

--- a/table_b.py
+++ b/table_b.py
@@ -23,7 +23,7 @@ index = pd.MultiIndex.from_tuples(
         ('Immunosuppressive treatment, n (%)', 'Anti-CD20'),
         ('Immunosuppressive treatment, n (%)', 'CAR-T'),
         ('Immunosuppressive treatment, n (%)', 'HSCT'),
-        ('Immunosuppressive treatment, n (%)', 'Other'),
+        ('Immunosuppressive treatment, n (%)', 'Other\u00b2'),
         ('Immunosuppressive treatment, n (%)', 'None'),
         ('Glucocorticoid use, n (%)', ''),
         ('SARS-CoV-2 vaccination, n (%)', ''),
@@ -95,7 +95,7 @@ def build_table_b():
         ('Anti-CD20', 'flag_cd20'),
         ('CAR-T', 'flag_cart'),
         ('HSCT', 'flag_hsct'),
-        ('Other', 'flag_immuno_other'),
+        ('Other\u00b2', 'flag_immuno_other'),
         ('None', 'flag_immuno_none'),
     ]
     for lbl, col in pairs:
@@ -146,7 +146,7 @@ def build_table_b():
     foot = (
         '- NMV-r, nirmatrelvir-ritonavir.\n'
         '1: Treatment setting where prolonged NMV-r was administered.\n'
-        f'2: Other immunosuppressive treatment: {extra}.'
+        f'2: Other immunosuppressive treatment includes: {extra}.'
     )
     table_b.attrs['footnote'] = foot
     table_b_raw.attrs['footnote'] = foot

--- a/tables.md
+++ b/tables.md
@@ -37,7 +37,7 @@
 |                                    | Transplantation          | 4 (3.8%)   | 3 (9.1%)      | 1 (1.8%)      | 0.138     |
 | Immunosuppressive treatment, n (%) |                          |            |               |               |           |
 |                                    | Anti-CD20                | 77 (74.0%) | 23 (69.7%)    | 46 (80.7%)    | 0.352     |
-|                                    | Other                    | 15 (14.4%) | 6 (18.2%)     | 5 (8.8%)      | 0.202     |
+|                                    | Other²                   | 15 (14.4%) | 6 (18.2%)     | 5 (8.8%)      | 0.202     |
 |                                    | None                     | 6 (5.8%)   | 2 (6.1%)      | 2 (3.5%)      | 0.622     |
 |                                    | HSCT                     | 3 (2.9%)   | 2 (6.1%)      | 1 (1.8%)      | 0.552     |
 |                                    | CAR-T                    | 3 (2.9%)   | 0 (0.0%)      | 3 (5.3%)      | 0.296     |
@@ -51,7 +51,7 @@
 
 - NMV-r, nirmatrelvir-ritonavir.    
 1: Treatment setting where prolonged NMV-r was administered.    
-2: Other immunosuppressive treatment: Other; HSCT, CD20; CD20, CAR-T.  
+2: Other immunosuppressive treatment includes: Other; HSCT, CD20; CD20, CAR-T.  
 
 \newpage
 # Table C. Detailed Patient Characteristics

--- a/tables_with_test.md
+++ b/tables_with_test.md
@@ -36,7 +36,7 @@
 |                                    | Transplantation          | 4 (3.8%)   | 3 (9.1%)      | 1 (1.8%)      | 0.138     | Fisher         |
 | Immunosuppressive treatment, n (%) |                          |            |               |               |           |                |
 |                                    | Anti-CD20                | 77 (74.0%) | 23 (69.7%)    | 46 (80.7%)    | 0.352     | Chi2 df=1      |
-|                                    | Other                    | 15 (14.4%) | 6 (18.2%)     | 5 (8.8%)      | 0.202     | Fisher         |
+|                                    | Other²                   | 15 (14.4%) | 6 (18.2%)     | 5 (8.8%)      | 0.202     | Fisher         |
 |                                    | None                     | 6 (5.8%)   | 2 (6.1%)      | 2 (3.5%)      | 0.622     | Fisher         |
 |                                    | HSCT                     | 3 (2.9%)   | 2 (6.1%)      | 1 (1.8%)      | 0.552     |                |
 |                                    | CAR-T                    | 3 (2.9%)   | 0 (0.0%)      | 3 (5.3%)      | 0.296     | Fisher         |
@@ -50,7 +50,7 @@
 
 - NMV-r, nirmatrelvir-ritonavir.
 1: Treatment setting where prolonged NMV-r was administered.
-2: Other immunosuppressive treatment: Other; HSCT, CD20; CD20, CAR-T.
+2: Other immunosuppressive treatment includes: Other; HSCT, CD20; CD20, CAR-T.
 
 # Table C. Detailed Patient Characteristics
 


### PR DESCRIPTION
## Summary
- document that Other is a composite category for immunosuppression
- regenerate tables with updated footnote

## Testing
- `python run_tables.py`

------
https://chatgpt.com/codex/tasks/task_e_688a18ed67708333a1b9346322205acd