### PR TITLE
Fix dataset path and handle missing abbreviations

### DIFF
--- a/data_preprocessing.py
+++ b/data_preprocessing.py
@@ -2,7 +2,7 @@ import pandas as pd
 import numpy as np
 import re
 from scipy.stats import chi2_contingency, fisher_exact, mannwhitneyu, shapiro, ttest_ind
-FILE_PATH = 'data characteristics v10.xlsx'
+FILE_PATH = 'data_characteristics_v10.xlsx'
 COL_OTHER = '1st line treatment any other antiviral drugs \n(days) [dosage]'
 COL_NMV_STD = '1st line Paxlovid standard duration treatment courses \n(n)'
 COL_THERAPY = (
@@ -37,12 +37,15 @@ COMBO = load_sheet('subgroup combo', 'subgroup combo, n=57')
 TOTAL_N = len(TOTAL)
 MONO_N = len(MONO)
 COMBO_N = len(COMBO)
-ABBREV_DF = pd.read_excel(
-    FILE_PATH,
-    sheet_name='primary cohort, n=104',
-    usecols='H:I',
-    header=106,
-).dropna(how='all')
+try:
+    ABBREV_DF = pd.read_excel(
+        FILE_PATH,
+        sheet_name='primary cohort, n=104',
+        usecols='H:I',
+        header=106,
+    ).dropna(how='all')
+except ValueError:
+    ABBREV_DF = pd.DataFrame(columns=['Abbreviation', 'Full Form'])
 ABBREV_DF.columns = ['Abbreviation', 'Full Form']
 for _df in (TOTAL, MONO, COMBO):
     if 'baseline therapy cohort' in _df.columns and COL_BASE not in _df.columns:


### PR DESCRIPTION
## Summary
- correct Excel filename in preprocessing
- make abbreviation section optional

## Testing
- `flake8`
- `pytest -q`
- `python run_tables.py`

------
https://chatgpt.com/codex/tasks/task_e_688a1e47d6d88333ae709c13d9386afa