### PR TITLE
Update run_tables to generate only code.md

### DIFF
--- a/code.md
+++ b/code.md
@@ -1,3 +1,4 @@
+# data_preprocessing.py
 import pandas as pd
 import numpy as np
 import re
@@ -426,6 +427,7 @@ if __name__ == '__main__':
     print(COMBO.shape)
     print(baseline_stats())
 
+# table_a.py
 def build_table_a():
     days_t, courses_t = parse_ext(TOTAL[COL_EXT])
     days_m, courses_m = parse_ext(MONO[COL_EXT])
@@ -657,6 +659,7 @@ if __name__ == '__main__':
         'when no subsequent antiviral therapy was administered.'
     )
 
+# table_b.py
 index = pd.MultiIndex.from_tuples(
     [
         ('N =', ''),
@@ -829,6 +832,7 @@ __all__ = [
     'add_mean_range',
 ]
 
+# table_c.py
 index = pd.MultiIndex.from_tuples(
     [
         ('Haematological malignancy, n (%)', ''),
@@ -972,6 +976,7 @@ if __name__ == '__main__':
     print('Table C. Detailed Patient Characteristics.')
     print(build_table_c().to_string())
 
+# table_d.py
 COL_ERAD = 'eradication outcome successful\n[yes / no]'
 COL_SURV = 'survival outcome\n[yes / no]'
 COL_AE_YN = 'any adverse events\n[yes / no]'

--- a/run_tables.py
+++ b/run_tables.py
@@ -400,11 +400,11 @@ def main():
         f.write(section_no_test("Table D. Outcomes in all cohorts", t4, subrows=False))
     out_code = "code.md"
     clean(out_code)
+    content = "# data_preprocessing.py\n" + open("data_preprocessing.py").read().rstrip() + "\n\n"
+    for name in ["table_a.py", "table_b.py", "table_c.py", "table_d.py"]:
+        content += f"# {name}\n" + code_without_imports(name) + "\n\n"
     with open(out_code, "w") as f:
-        f.write(open("data_preprocessing.py").read().rstrip() + "\n\n")
-        for name in ["table_a.py", "table_b.py", "table_c.py", "table_d.py"]:
-            f.write(code_without_imports(name))
-            f.write("\n\n")
+        f.write(content)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- remove the unused `code.me`
- update `run_tables.py` so it writes only `code.md`
- regenerate outputs

## Testing
- `flake8`
- `pytest -q`
- `python run_tables.py`


------
https://chatgpt.com/codex/tasks/task_e_688a565a49e08333847a285d049d7ba3