### PR TITLE
use regex for immuno classification and add tests

### DIFF
--- a/code.md
+++ b/code.md
@@ -245,9 +245,19 @@ def classify_immuno(x):
     s = normalize_text(x)
     if s in NONE_SET:
         return 'None'
-    has_cd20 = 'cd20' in s
-    has_car = 'car' in s
-    has_hsct = 'hsct' in s
+    cd20_pattern = (
+        r'\b(cd20|rituximab|ocrelizumab|obinutuzumab|ofatumumab|ublituximab)\b'
+    )
+    car_pattern = (
+        r'\b(car[-\s]?t|cart|tisa-cel|axi-cel|liso-cel|brexu-cel|chimeric\s+antigen\s+receptor)\b'
+    )
+    hsct_pattern = (
+        r'\b(hsct|stem\s+cell\s+transplant|stem\s+cell\s+transplantation|hematopoietic\s+stem\s+cell|'
+        r'bone\s+marrow(?:\s+transplant)?|bmt)\b'
+    )
+    has_cd20 = bool(re.search(cd20_pattern, s))
+    has_car = bool(re.search(car_pattern, s))
+    has_hsct = bool(re.search(hsct_pattern, s))
     if sum([has_cd20, has_car, has_hsct]) > 1:
         return 'Mixed'
     if has_cd20:

--- a/data_preprocessing.py
+++ b/data_preprocessing.py
@@ -244,9 +244,19 @@ def classify_immuno(x):
     s = normalize_text(x)
     if s in NONE_SET:
         return 'None'
-    has_cd20 = 'cd20' in s
-    has_car = 'car' in s
-    has_hsct = 'hsct' in s
+    cd20_pattern = (
+        r'\b(cd20|rituximab|ocrelizumab|obinutuzumab|ofatumumab|ublituximab)\b'
+    )
+    car_pattern = (
+        r'\b(car[-\s]?t|cart|tisa-cel|axi-cel|liso-cel|brexu-cel|chimeric\s+antigen\s+receptor)\b'
+    )
+    hsct_pattern = (
+        r'\b(hsct|stem\s+cell\s+transplant|stem\s+cell\s+transplantation|hematopoietic\s+stem\s+cell|'
+        r'bone\s+marrow(?:\s+transplant)?|bmt)\b'
+    )
+    has_cd20 = bool(re.search(cd20_pattern, s))
+    has_car = bool(re.search(car_pattern, s))
+    has_hsct = bool(re.search(hsct_pattern, s))
     if sum([has_cd20, has_car, has_hsct]) > 1:
         return 'Mixed'
     if has_cd20:

--- a/tests/test_immuno_classification.py
+++ b/tests/test_immuno_classification.py
@@ -1,0 +1,30 @@
+import pytest
+from data_preprocessing import classify_immuno
+
+CASES = {
+    'CD20': 'Anti-CD20',
+    'rituximab': 'Anti-CD20',
+    'ocrelizumab': 'Anti-CD20',
+    'obinutuzumab': 'Anti-CD20',
+    'ofatumumab': 'Anti-CD20',
+    'car-t': 'CAR-T',
+    'car t': 'CAR-T',
+    'cart': 'CAR-T',
+    'chimeric antigen receptor': 'CAR-T',
+    'tisa-cel': 'CAR-T',
+    'axi-cel': 'CAR-T',
+    'hsct': 'HSCT',
+    'hematopoietic stem cell': 'HSCT',
+    'stem cell transplant': 'HSCT',
+    'bone marrow': 'HSCT',
+    'none': 'None',
+    '': 'None',
+    'no antiviral': 'None',
+    'rituximab and car-t': 'Mixed',
+    'unknown therapy': 'Other'
+}
+
+
+@pytest.mark.parametrize('label,expected', CASES.items())
+def test_classify_immuno(label, expected):
+    assert classify_immuno(label) == expected


### PR DESCRIPTION
## Summary
- refine immunosuppressive therapy classification using regex patterns with comprehensive synonyms
- add unit tests covering known therapy names for immuno classification

## Testing
- `flake8 data_preprocessing.py tests/test_immuno_classification.py`
- `python -m pytest tests/test_immuno_classification.py`
- `python run_tables.py`


------
https://chatgpt.com/codex/tasks/task_e_6890f3ee03a083339a5f03b752bd76fb